### PR TITLE
newline fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -999,4 +999,10 @@ a.a <=> 1
 a.a -= 1
 a.a <=> 0"
     );
+
+    test_multiple!(
+        newline_regression,
+        simple: "a := 1 // blargh \na += 1 // blargh \n a <=> 2 // HARGH",
+        expressions: "1 + 1 // blargh \n 2 // blargh \n // HARGH \n",
+    );
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -123,7 +123,7 @@ pub enum Token {
     #[token("\n")]
     Newline,
 
-    #[regex(r"//[^\n]*\n", logos::skip)]
+    #[regex(r"//[^\n]*", logos::skip)]
     Comment,
 
     #[regex(r"[ \t\r]", logos::skip)]

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -229,8 +229,8 @@ mod tests {
 
     #[test]
     fn comment() {
-        lex_once("// a\n1");
-        assert_eq!(lex("1// a\n2").len(), 2);
-        assert_eq!(lex("1\n// a\n2").len(), 3); // newline is also a token
+        assert_eq!(lex("// a\n1").len(), 2);
+        assert_eq!(lex("1// a\n2").len(), 3);
+        assert_eq!(lex("1\n// a\n2").len(), 4); // newline is also a token
     }
 }


### PR DESCRIPTION
We had truble parsing `//` comments on the same line as some code,
this was because of the eaten newline.
