### PR TITLE
op copy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ impl Blob {
 /// machine carries out when running the
 /// "byte-code".
 ///
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum Op {
     /// This instruction should never be run.
     /// Finding it in a program is a critical error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,7 @@ impl From<Type> for Value {
 
 #[derive(Clone)]
 pub enum Value {
+    Ty(Type),
     Blob(usize),
     BlobInstance(usize, Rc<RefCell<Vec<Value>>>),
     Tuple(Rc<Vec<Value>>),
@@ -178,6 +179,7 @@ pub enum Value {
 impl Debug for Value {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Value::Ty(ty) => write!(fmt, "(type {:?})", ty),
             Value::Blob(i) => write!(fmt, "(blob {})", i),
             Value::BlobInstance(i, v) => write!(fmt, "(inst {} {:?})", i, v),
             Value::Float(f) => write!(fmt, "(float {})", f),
@@ -307,11 +309,11 @@ pub enum Op {
     ///
     /// {A, B} - Copy - {A, B, B}
     Copy,
-    /// Adds the given value to the top of the stack.
+    /// Adds the value indexed in the `constants-vector` to the top of the stack.
     /// Also links upvalues if the value is a function.
     ///
     /// {A} - Constant(B) - {A, B}
-    Constant(Value),
+    Constant(usize),
     /// Creates a new [Tuple] with the given size and place it on the top
     /// of the stack.
     ///
@@ -326,15 +328,17 @@ pub enum Op {
     /// Looks up a field by the given name
     /// and replaces the parent with it.
     /// Currently only expects [Value::Blob].
+    /// (name is looked up in the internal string-list)
     ///
     /// {O} - Get(F) - {O.F}
-    Get(String),
+    Get(usize),
     /// Looks up a field by the given name
     /// and replaces the current value in the object.
     /// Currently only expects [Value::Blob].
+    /// (name is looked up in the internal string-list)
     ///
     /// {O} - Set(F) - {}
-    Set(String),
+    Set(usize),
 
     /// Adds the two top elements on the stack,
     /// using the function [op::add]. The result
@@ -452,9 +456,10 @@ pub enum Op {
     /// makes sure the top value on the stack
     /// is of the given type, and is ment to signal
     /// that the "variable" is added.
+    /// (The type is looked up in the constants vector)
     ///
     /// Does not affect the stack.
-    Define(Type),
+    Define(usize),
 
     /// Calls "something" with the given number
     /// of arguments. The callable value is
@@ -702,6 +707,8 @@ pub struct Prog {
     pub blocks: Vec<Rc<RefCell<Block>>>,
     pub blobs: Vec<Rc<Blob>>,
     pub functions: Vec<RustFunction>,
+    pub constants: Vec<Value>,
+    pub strings: Vec<String>,
 }
 
 #[cfg(test)]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -58,6 +58,8 @@ pub struct VM {
     frames: Vec<Frame>,
 
     blobs: Vec<Rc<Blob>>,
+    constants: Vec<Value>,
+    strings: Vec<String>,
 
     pub print_blocks: bool,
     pub print_ops: bool,
@@ -83,7 +85,11 @@ impl VM {
 
             stack: Vec::new(),
             frames: Vec::new(),
+
             blobs: Vec::new(),
+            constants: Vec::new(),
+            strings: Vec::new(),
+
             print_blocks: false,
             print_ops: false,
 
@@ -130,6 +136,21 @@ impl VM {
     fn frame_mut(&mut self) -> &mut Frame {
         let last = self.frames.len() - 1;
         &mut self.frames[last]
+    }
+
+    fn constant(&self, slot: usize) -> &Value {
+        &self.constants[slot]
+    }
+
+    fn ty(&self, slot: usize) -> &Type {
+        match &self.constants[slot] {
+            Value::Ty(ty) => ty,
+            _ => self.crash_and_burn(),
+        }
+    }
+
+    fn string(&self, slot: usize) -> &String {
+        &self.strings[slot]
     }
 
     fn op(&self) -> Op {
@@ -197,7 +218,8 @@ impl VM {
 
             Op::Constant(value) => {
                 let offset = self.frame().stack_offset;
-                let value = match value {
+                let constant = self.constant(value).clone();
+                let value = match constant {
                     Value::Function(_, block) => {
                         let mut ups = Vec::new();
                         for (slot, is_up, _) in block.borrow().upvalues.iter() {
@@ -215,7 +237,7 @@ impl VM {
                         }
                         Value::Function(ups, block)
                     },
-                    _ => value.clone(),
+                    value => value,
                 };
                 self.push(value);
             }
@@ -240,23 +262,25 @@ impl VM {
                 }
             }
 
-            Op::Get(field) => {
+            Op::Get(field_ident) => {
                 let inst = self.pop();
+                let field = self.string(field_ident);
                 if let Value::BlobInstance(ty, values) = inst {
-                    let slot = self.blobs[ty].fields.get(&field).unwrap().0;
+                    let slot = self.blobs[ty].fields.get(field).unwrap().0;
                     self.push(values.borrow()[slot].clone());
                 } else {
-                    error!(self, ErrorKind::RuntimeTypeError(Op::Get(field.clone()), vec![inst]));
+                    error!(self, ErrorKind::RuntimeTypeError(Op::Get(field_ident), vec![inst]));
                 }
             }
 
-            Op::Set(field) => {
+            Op::Set(field_ident) => {
                 let (inst, value) = self.poppop();
+                let field = self.string(field_ident);
                 if let Value::BlobInstance(ty, values) = inst {
-                    let slot = self.blobs[ty].fields.get(&field).unwrap().0;
+                    let slot = self.blobs[ty].fields.get(field).unwrap().0;
                     values.borrow_mut()[slot] = value;
                 } else {
-                    error!(self, ErrorKind::RuntimeTypeError(Op::Get(field.clone()), vec![inst]));
+                    error!(self, ErrorKind::RuntimeTypeError(Op::Get(field_ident), vec![inst]));
                 }
             }
 
@@ -428,6 +452,9 @@ impl VM {
     pub(crate) fn init(&mut self, prog: &Prog) {
         let block = Rc::clone(&prog.blocks[0]);
         self.blobs = prog.blobs.clone();
+        self.constants = prog.constants.clone();
+        self.strings = prog.strings.clone();
+
         self.extern_functions = prog.functions.clone();
         self.stack.clear();
         self.frames.clear();
@@ -469,8 +496,8 @@ impl VM {
 
             Op::Yield => {}
 
-            Op::Constant(ref value) => {
-                match value.clone() {
+            Op::Constant(value) => {
+                match self.constant(value).clone() {
                     Value::Function(_, block) => {
                         self.push(Value::Function(Vec::new(), block.clone()));
 
@@ -500,34 +527,35 @@ impl VM {
                             }
                         };
                     },
-                    _ => {
+                    value => {
                         self.push(value.clone());
                     }
                 }
             }
 
-            Op::Get(field) => {
+            Op::Get(field_ident) => {
                 let inst = self.pop();
+                let field = self.string(field_ident);
                 if let Value::BlobInstance(ty, _) = inst {
-                    let value = Value::from(&self.blobs[ty].fields.get(&field).unwrap().1);
+                    let value = Value::from(&self.blobs[ty].fields.get(field).unwrap().1);
                     self.push(value);
                 } else {
                     self.push(Value::Nil);
-                    error!(self, ErrorKind::RuntimeTypeError(Op::Get(field.clone()), vec![inst]));
+                    error!(self, ErrorKind::RuntimeTypeError(Op::Get(field_ident), vec![inst]));
                 }
             }
 
-            Op::Set(field) => {
-                let value = self.pop();
-                let inst = self.pop();
+            Op::Set(field_ident) => {
+                let (inst, value) = self.poppop();
+                let field = self.string(field_ident);
 
                 if let Value::BlobInstance(ty, _) = inst {
-                    let ty = &self.blobs[ty].fields.get(&field).unwrap().1;
+                    let ty = &self.blobs[ty].fields.get(field).unwrap().1;
                     if ty != &Type::from(&value) {
-                        error!(self, ErrorKind::RuntimeTypeError(Op::Set(field.clone()), vec![inst]));
+                        error!(self, ErrorKind::RuntimeTypeError(Op::Set(field_ident), vec![inst]));
                     }
                 } else {
-                    error!(self, ErrorKind::RuntimeTypeError(Op::Set(field.clone()), vec![inst]));
+                    error!(self, ErrorKind::RuntimeTypeError(Op::Set(field_ident), vec![inst]));
                 }
             }
 
@@ -564,7 +592,8 @@ impl VM {
                 self.pop();
             }
 
-            Op::Define(ref ty) => {
+            Op::Define(ty) => {
+                let ty = self.ty(ty);
                 let top_type = self.stack.last().unwrap().into();
                 match (ty, top_type) {
                     (Type::Unknown, top_type)
@@ -707,6 +736,9 @@ impl VM {
         let mut errors = Vec::new();
 
         self.blobs = prog.blobs.clone();
+        self.constants = prog.constants.clone();
+        self.strings = prog.strings.clone();
+
         self.extern_functions = prog.functions.clone();
         for block in prog.blocks.iter() {
             errors.append(&mut self.typecheck_block(Rc::clone(block)));


### PR DESCRIPTION
Changed the compiler to intern strings (in a dumb way) and
put constants in a list. This gave us a speedup of ~15%.
I ran some informal tests and got this:


before | after
-- | --
~1.0s | ~1.2s



I was running this program:
```
fib := fn a:int -> int {
    if a < 2 { ret a }
    ret fib(a - 1) + fib(a - 2)
}

fib(30)
```

I'd say that's a pretty nice speedup!

A stepping stone towards #36 
