### PR TITLE
parse branch macro

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -68,6 +68,32 @@ macro_rules! parse_branch {
             $compiler.errors.extend(stored_errors);
         }
     };
+
+    ($compiler:expr, $block:expr, $call:expr) => {
+        {
+            let block_length = $block.ops.len();
+            let token_length = $compiler.curr;
+            let num_errors = $compiler.errors.len();
+            let mut stored_errors = Vec::new();
+            let mut success = false;
+            // We risk getting a lot of errors if we are in an invalid state
+            // when we start the parse.
+            while !$compiler.panic {
+                $call;
+                if !$compiler.panic {
+                    success = true;
+                    break;
+                }
+                $compiler.panic = false;
+                $compiler.curr = token_length;
+                let thrown_errors = $compiler.errors.len() - num_errors - 1;
+                stored_errors.extend($compiler.errors.split_off(thrown_errors));
+                $block.ops.truncate(block_length);
+                break;
+            }
+            success
+        }
+    };
 }
 
 nextable_enum!(Prec {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -41,32 +41,39 @@ macro_rules! expect {
 
 macro_rules! parse_branch {
     ($compiler:expr, $block:expr, [ $( $call:expr ),* ]) => {
-        let block_length = $block.ops.len();
-        let token_length = $compiler.curr;
-        let num_errors = $compiler.errors.len();
-        let mut stored_errors = Vec::new();
-        let mut success = false;
-        // We risk getting a lot of errors if we are in an invalid state
-        // when we start the parse.
-        while !$compiler.panic {
-            $(
-                $call;
-                if !$compiler.panic {
-                    success = true;
-                    break;
+        {
+            let block_length = $block.ops.len();
+            let token_length = $compiler.curr;
+            let num_errors = $compiler.errors.len();
+            let mut stored_errors = Vec::new();
+
+            // Closures for early return on success.
+            let success = (|| {
+                // We risk getting a lot of errors if we are in an invalid state
+                // when we start the parse.
+                if $compiler.panic {
+                    return false;
                 }
-                $compiler.panic = false;
-                $compiler.curr = token_length;
-                let thrown_errors = $compiler.errors.len() - num_errors - 1;
-                stored_errors.extend($compiler.errors.split_off(thrown_errors));
-                $block.ops.truncate(block_length);
-            )*
-            break;
+                $(
+                    $call;
+                    if !$compiler.panic {
+                        return true;
+                    }
+                    $compiler.panic = false;
+                    $compiler.curr = token_length;
+                    let thrown_errors = $compiler.errors.len() - num_errors - 1;
+                    stored_errors.extend($compiler.errors.split_off(thrown_errors));
+                    $block.ops.truncate(block_length);
+                )*
+                false
+            })();
+
+            if !success {
+                $compiler.errors.extend(stored_errors);
+            }
+            success
         }
 
-        if !success {
-            $compiler.errors.extend(stored_errors);
-        }
     };
 
     ($compiler:expr, $block:expr, $call:expr) => {
@@ -75,23 +82,24 @@ macro_rules! parse_branch {
             let token_length = $compiler.curr;
             let num_errors = $compiler.errors.len();
             let mut stored_errors = Vec::new();
-            let mut success = false;
-            // We risk getting a lot of errors if we are in an invalid state
-            // when we start the parse.
-            while !$compiler.panic {
+            // Closures for early return on success.
+            (|| {
+                // We risk getting a lot of errors if we are in an invalid state
+                // when we start the parse.
+                if $compiler.panic {
+                    return false;
+                }
                 $call;
                 if !$compiler.panic {
-                    success = true;
-                    break;
+                    return true;
                 }
                 $compiler.panic = false;
                 $compiler.curr = token_length;
                 let thrown_errors = $compiler.errors.len() - num_errors - 1;
                 stored_errors.extend($compiler.errors.split_off(thrown_errors));
                 $block.ops.truncate(block_length);
-                break;
-            }
-            success
+                false
+            })()
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -741,7 +741,7 @@ mod tests {
                             println!("{}", e);
                         }
                         println!("  {} - FAILED\n", stringify!($fn));
-                        unreachable!();
+                        panic!();
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -734,7 +734,16 @@ mod tests {
         ($fn:ident, $prog:literal) => {
             #[test]
             fn $fn() {
-                $crate::run_string($prog, true, Vec::new()).unwrap();
+                match $crate::run_string($prog, true, Vec::new()) {
+                    Ok(()) => {},
+                    Err(errs) => {
+                        for e in errs.iter() {
+                            println!("{}", e);
+                        }
+                        println!("  {} - FAILED\n", stringify!($fn));
+                        unreachable!();
+                    }
+                }
             }
         };
         ($fn:ident, $prog:literal, $errs:tt) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -729,27 +729,55 @@ mod tests {
         };
     }
 
+    use std::time::Duration;
+    use std::sync::mpsc;
+    use std::thread;
+
+    // Shamelessly stolen from https://github.com/rust-lang/rfcs/issues/2798
+    pub fn panic_after<T, F>(d: Duration, f: F) -> T
+    where
+        T: Send + 'static,
+        F: FnOnce() -> T,
+        F: Send + 'static,
+    {
+        let (done_tx, done_rx) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            let val = f();
+            done_tx.send(()).expect("Unable to send completion signal");
+            val
+        });
+
+        match done_rx.recv_timeout(d) {
+            Ok(_) => handle.join().expect("Thread panicked"),
+            Err(_) => panic!("Thread took too long"),
+        }
+    }
+
     #[macro_export]
     macro_rules! test_string {
         ($fn:ident, $prog:literal) => {
             #[test]
             fn $fn() {
-                match $crate::run_string($prog, true, Vec::new()) {
-                    Ok(()) => {},
-                    Err(errs) => {
-                        for e in errs.iter() {
-                            println!("{}", e);
+                crate::tests::panic_after(std::time::Duration::from_millis(500), || {
+                    match $crate::run_string($prog, true, Vec::new()) {
+                        Ok(()) => {},
+                        Err(errs) => {
+                            for e in errs.iter() {
+                                println!("{}", e);
+                            }
+                            println!("  {} - FAILED\n", stringify!($fn));
+                            panic!();
                         }
-                        println!("  {} - FAILED\n", stringify!($fn));
-                        panic!();
                     }
-                }
+                });
             }
         };
         ($fn:ident, $prog:literal, $errs:tt) => {
             #[test]
             fn $fn() {
-                $crate::assert_errs!($crate::run_string($prog, true, Vec::new()), $errs);
+                crate::tests::panic_after(std::time::Duration::from_millis(500), || {
+                    $crate::assert_errs!($crate::run_string($prog, true, Vec::new()), $errs);
+                })
             }
         }
     }


### PR DESCRIPTION
Sometimes we allow branches in the compiler, this is fine, but the way to do it is kinda cumbersome.

This PR adds a macro that generalises the branching, and makes it gives better error messages.

(I also fixed up the `run\_string!` macro a bit, it needed some love.)
