### PR TITLE
fancy call syntax

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -389,7 +389,7 @@ impl Compiler {
             Token::Bool(_) => self.value(block),
             Token::String(_) => self.value(block),
 
-            Token::Not => self.unary(block),
+            Token::Bang => self.unary(block),
 
             _ => { return false; },
         }
@@ -607,9 +607,7 @@ impl Compiler {
                 }
             },
 
-            Token::Not => {
-                // I suspect this will be wierd with the boolean NOT
-                // operator...
+            Token::Bang => {
                 self.eat();
                 loop {
                     match self.peek() {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -489,7 +489,7 @@ impl Compiler {
     fn unary(&mut self, block: &mut Block) {
         let op = match self.eat() {
             Token::Minus => Op::Neg,
-            Token::Not => Op::Not,
+            Token::Bang => Op::Not,
             _ => { error!(self, "Invalid unary operator"); Op::Neg },
         };
         self.parse_precedence(block, Prec::Factor);

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -638,7 +638,7 @@ impl Compiler {
             }
 
             _ => {
-                error!(self, "Not a valid function call, expected a '!' or a '('.");
+                error!(self, "Invalid function call. Expected '!' or '('.");
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1046,6 +1046,14 @@ a.a <=> 0"
     );
 
     test_multiple!(
+        fancy_call,
+        not: "f := fn {}\n f!\n",
+        one_arg: "f := fn a:int { a <=> 1 }\n f! 1\n",
+        two_arg: "f := fn a:int, b:int { b <=> 3 }\n f! 1, 1 + 2\n",
+        three_arg: "f := fn a:int, b:int, c:int { c <=> 13 }\n f! 1, 1 + 2, 1 + 4 * 3\n",
+    );
+
+    test_multiple!(
         newline_regression,
         simple: "a := 1 // blargh \na += 1 // blargh \n a <=> 2 // HARGH",
         expressions: "1 + 1 // blargh \n 2 // blargh \n // HARGH \n",

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -112,7 +112,7 @@ pub enum Token {
     #[token("||")]
     Or,
     #[token("!")]
-    Not,
+    Bang,
 
     #[token(",")]
     Comma,


### PR DESCRIPTION
The original idea for the call syntax was:

```sylt
f := fn {}
f!
g := fn a:int {}
g 1
```

This created problems with `-1` being a valid expression and thus subtractions became function-calls.
We don't want that! So I settled on using this syntax:
```sylt
f := fn {}
f!
g := fn a:int {}
g! 1
```
Here the `!` is the call operator, very similar to the parentasis,
but you don't have to close it. :D
I hate closing things, like closing #48

Some duplicate commits from reworking some of the tests. Sorry about that.
