### PR TITLE
no-compilation order for constants

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -630,8 +630,8 @@ impl Compiler {
             Value::Function(_, b) if b.borrow().name == name => Some(i),
             _ => None,
         });
-        if res.is_some() {
-            return res.unwrap();
+        if let Some(res) = res {
+            return res;
         }
         let constant = self.add_constant(Value::Nil);
         let line = self.line();

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -917,6 +917,9 @@ impl Compiler {
                 if let Entry::Occupied(entry) = self.unkowns.entry(String::from(name)) {
                     let (_, (slot, _)) = entry.remove_entry();
                     self.constants[slot] = self.constants.pop().unwrap();
+                    add_op(self, block, Op::Link(slot));
+                } else {
+                    add_op(self, block, Op::Link(self.constants.len() - 1));
                 }
                 return;
             }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -151,16 +151,6 @@ impl Frame {
         }
     }
 
-    fn count_this_scope(&self) -> usize {
-        for (i, var) in self.stack.iter().rev().enumerate() {
-            println!("i:{} - {} == {}", i, var.scope, self.scope);
-            if var.scope != self.scope {
-                // return i;
-            }
-        }
-        return self.stack.len();
-    }
-
     fn push_loop(&mut self) {
         self.loops.push(Vec::new());
     }
@@ -177,7 +167,7 @@ impl Frame {
         }
     }
 
-    fn add_continue(&mut self, addr: usize, stacksize: usize, block: &mut Block) -> Result<(), ()> {
+    fn add_continue(&mut self, addr: usize, stacksize: usize) -> Result<(), ()> {
         if let Some(top) = self.loops.last_mut() {
             top.push((addr, stacksize, LoopOp::Continue));
             Ok(())
@@ -186,7 +176,7 @@ impl Frame {
         }
     }
 
-    fn add_break(&mut self, addr: usize, stacksize: usize, block: &mut Block) -> Result<(), ()> {
+    fn add_break(&mut self, addr: usize, stacksize: usize) -> Result<(), ()> {
         if let Some(top) = self.loops.last_mut() {
             top.push((addr, stacksize, LoopOp::Break));
             Ok(())
@@ -1278,7 +1268,7 @@ impl Compiler {
                 self.eat();
                 let addr = add_op(self, block, Op::Illegal);
                 let stack_size = self.frame().stack.len();
-                if self.frame_mut().add_break(addr, stack_size, block).is_err() {;
+                if self.frame_mut().add_break(addr, stack_size).is_err() {
                     error!(self, "Cannot place 'break' outside of loop.");
                 }
             }
@@ -1287,7 +1277,7 @@ impl Compiler {
                 self.eat();
                 let addr = add_op(self, block, Op::Illegal);
                 let stack_size = self.frame().stack.len();
-                if self.frame_mut().add_continue(addr, stack_size, block).is_err() {
+                if self.frame_mut().add_continue(addr, stack_size).is_err() {
                     error!(self, "Cannot place 'continue' outside of loop.");
                 }
             }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1399,7 +1399,7 @@ impl Compiler {
             let errors: Vec<_> = self.unkowns.iter().map(|(name, (_, line))|
                 (ErrorKind::SyntaxError(*line, Token::Identifier(name.clone())),
                  *line,
-                 format!("Usage of undefined 'blob': '{}'.", name,)
+                 format!("Usage of undefined value: '{}'.", name,)
                 ))
                 .collect();
             for (e, l, m) in errors.iter() {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1085,7 +1085,7 @@ impl Compiler {
                     "float" => Ok(Type::Float),
                     "bool" => Ok(Type::Bool),
                     "str" => Ok(Type::String),
-                    x => self.find_blob(x).map(|blob| Type::BlobInstance(blob)).ok_or(()),
+                    x => self.find_blob(x).map(|blob| Type::Instance(blob)).ok_or(()),
                 }
             }
             _ => Err(()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -833,6 +833,12 @@ mod tests {
         assert_errs!(run_string("a :: 2\nq :: fn { a = 2 }\n", true, Vec::new()), [ErrorKind::SyntaxError(_, _)]);
     }
 
+    #[test]
+    fn undefined_blob() {
+        assert_errs!(run_string("a :: B()\n", true, Vec::new()), [ErrorKind::SyntaxError(_, _)]);
+    }
+
+
     macro_rules! test_multiple {
         ($mod:ident, $( $fn:ident : $prog:literal ),+ $( , )? ) => {
             mod $mod {
@@ -1183,6 +1189,7 @@ a := 0
 a <=> -1
 ",
     );
+
     test_multiple!(
         declaration_order,
         simple: "
@@ -1193,5 +1200,15 @@ blob A {
 }
 ",
 
+        complex: "
+a := A()
+b := B()
+c := C()
+b2 := B()
+
+blob A { }
+blob C { }
+blob B { }
+",
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1192,7 +1192,7 @@ a <=> -1
 
     test_multiple!(
         declaration_order,
-        simple: "
+        blob_simple: "
 a := A()
 
 blob A {
@@ -1200,15 +1200,42 @@ blob A {
 }
 ",
 
-        complex: "
+        blob_complex: "
 a := A()
 b := B()
 c := C()
 b2 := B()
 
-blob A { }
+blob A {
+    c: C
+}
 blob C { }
 blob B { }
+",
+
+        constant_function: "
+a()
+a :: fn {}
+",
+
+        constant_function_complex: "
+h :: fn -> int {
+    ret 3
+}
+
+a() <=> 3
+
+k :: fn -> int {
+    ret h()
+}
+
+a :: fn -> int {
+    ret q()
+}
+
+q :: fn -> int {
+    ret k()
+}
 ",
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1023,19 +1023,6 @@ b() <=> 3
 
 a() <=> 4
 ",
-
-        //TODO this tests doesn't terminate in proper time if we print blocks and ops
-        fibonacci: "fibonacci : fn int -> int = fn n: int -> int {
-                      if n == 0 {
-                        ret 0
-                      } else if n == 1 {
-                        ret 1
-                      } else if n < 0 {
-                        <!>
-                      }
-                      ret fibonacci(n - 1) + fibonacci(n - 2)
-                    }
-                    fibonacci(10) <=> 55",
     );
 
     test_multiple!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,14 +85,14 @@ pub enum Type {
     Tuple(Vec<Type>),
     Function(Vec<Type>, Box<Type>),
     Blob(usize),
-    BlobInstance(usize),
+    Instance(usize),
 }
 
 impl PartialEq for Type {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Type::Void, Type::Void) => true,
-            (Type::BlobInstance(a), Type::BlobInstance(b)) => a == b,
+            (Type::Instance(a), Type::Instance(b)) => a == b,
             (Type::Blob(a), Type::Blob(b)) => a == b,
             (Type::Int, Type::Int) => true,
             (Type::Float, Type::Float) => true,
@@ -111,7 +111,7 @@ impl PartialEq for Type {
 impl From<&Value> for Type {
     fn from(value: &Value) -> Type {
         match value {
-            Value::BlobInstance(i, _) => Type::BlobInstance(*i),
+            Value::Instance(i, _) => Type::Instance(*i),
             Value::Blob(i) => Type::Blob(*i),
             Value::Tuple(v) => {
                 Type::Tuple(v.iter().map(|x| Type::from(x)).collect())
@@ -137,7 +137,7 @@ impl From<&Type> for Value {
         match ty {
             Type::Void => Value::Nil,
             Type::Blob(i) => Value::Blob(*i),
-            Type::BlobInstance(i) => Value::BlobInstance(*i, Rc::new(RefCell::new(Vec::new()))),
+            Type::Instance(i) => Value::Instance(*i, Rc::new(RefCell::new(Vec::new()))),
             Type::Tuple(fields) => {
                 Value::Tuple(Rc::new(fields.iter().map(Value::from).collect()))
             }
@@ -164,7 +164,7 @@ impl From<Type> for Value {
 pub enum Value {
     Ty(Type),
     Blob(usize),
-    BlobInstance(usize, Rc<RefCell<Vec<Value>>>),
+    Instance(usize, Rc<RefCell<Vec<Value>>>),
     Tuple(Rc<Vec<Value>>),
     Float(f64),
     Int(i64),
@@ -181,7 +181,7 @@ impl Debug for Value {
         match self {
             Value::Ty(ty) => write!(fmt, "(type {:?})", ty),
             Value::Blob(i) => write!(fmt, "(blob {})", i),
-            Value::BlobInstance(i, v) => write!(fmt, "(inst {} {:?})", i, v),
+            Value::Instance(i, v) => write!(fmt, "(inst {} {:?})", i, v),
             Value::Float(f) => write!(fmt, "(float {})", f),
             Value::Int(i) => write!(fmt, "(int {})", i),
             Value::Bool(b) => write!(fmt, "(bool {})", b),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1263,5 +1263,24 @@ f() <=> 4
 f() <=> 5
 ",
 
+        constants_in_inner_functions: "
+q : int = 0
+
+f :: fn -> fn -> {
+    g :: fn {
+        q += 1
+    }
+    ret g
+}
+
+g := f()
+g()
+q <=> 3
+g()
+q <=> 4
+g()
+q <=> 5
+",
+
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1045,7 +1045,11 @@ a() <=> 4
                           a.a = 2
                           a.b = 3
                           a.a + a.b <=> 5
-                          5 <=> a.a + a.b"
+                          5 <=> a.a + a.b",
+        blob_infer: "
+blob A { }
+a : A = A()
+",
     );
 
     test_multiple!(tuples,
@@ -1212,6 +1216,13 @@ blob A {
 blob C { }
 blob B { }
 ",
+
+        blob_infer: "
+blob A { }
+
+a : A = A()
+",
+
 
         constant_function: "
 a()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,6 +480,12 @@ pub enum Op {
     /// Does not affect the stack.
     Define(usize),
 
+    /// Links the upvalues for the given constant
+    /// function. This updates the constant stack.
+    ///
+    /// Does not affect the stack.
+    Link(usize),
+
     /// Calls "something" with the given number
     /// of arguments. The callable value is
     /// then replaced with the result.
@@ -1275,11 +1281,11 @@ f :: fn -> fn -> {
 
 g := f()
 g()
+q <=> 1
+g()
+q <=> 2
+g()
 q <=> 3
-g()
-q <=> 4
-g()
-q <=> 5
 ",
 
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1248,5 +1248,20 @@ q :: fn -> int {
     ret k()
 }
 ",
+
+        constant_function_closure: "
+q := 1
+
+f :: fn -> int {
+    q += 1
+    ret q
+}
+
+f() <=> 2
+f() <=> 3
+f() <=> 4
+f() <=> 5
+",
+
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1183,4 +1183,15 @@ a := 0
 a <=> -1
 ",
     );
+    test_multiple!(
+        declaration_order,
+        simple: "
+a := A()
+
+blob A {
+    a: int
+}
+",
+
+    );
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -283,7 +283,7 @@ impl VM {
             Op::Get(field) => {
                 let inst = self.pop();
                 let field = self.string(field);
-                if let Value::BlobInstance(ty, values) = inst {
+                if let Value::Instance(ty, values) = inst {
                     let slot = self.blobs[ty].fields.get(field).unwrap().0;
                     self.push(values.borrow()[slot].clone());
                 } else {
@@ -294,7 +294,7 @@ impl VM {
             Op::Set(field) => {
                 let (inst, value) = self.poppop();
                 let field = self.string(field);
-                if let Value::BlobInstance(ty, values) = inst {
+                if let Value::Instance(ty, values) = inst {
                     let slot = self.blobs[ty].fields.get(field).unwrap().0;
                     values.borrow_mut()[slot] = value;
                 } else {
@@ -402,7 +402,7 @@ impl VM {
                         }
 
                         self.pop();
-                        self.push(Value::BlobInstance(blob_id, Rc::new(RefCell::new(values))));
+                        self.push(Value::Instance(blob_id, Rc::new(RefCell::new(values))));
                     }
                     Value::Function(_, block) => {
                         let inner = block.borrow();
@@ -569,7 +569,7 @@ impl VM {
             Op::Get(field) => {
                 let inst = self.pop();
                 let field = self.string(field);
-                if let Value::BlobInstance(ty, _) = inst {
+                if let Value::Instance(ty, _) = inst {
                     let value = Value::from(&self.blobs[ty].fields.get(field).unwrap().1);
                     self.push(value);
                 } else {
@@ -582,7 +582,7 @@ impl VM {
                 let (inst, value) = self.poppop();
                 let field = self.string(field);
 
-                if let Value::BlobInstance(ty, _) = inst {
+                if let Value::Instance(ty, _) = inst {
                     let ty = &self.blobs[ty].fields.get(field).unwrap().1;
                     if ty != &Type::from(&value) {
                         error!(self, ErrorKind::RuntimeTypeError(op, vec![inst]));
@@ -659,7 +659,7 @@ impl VM {
                         }
 
                         self.pop();
-                        self.push(Value::BlobInstance(blob_id, Rc::new(RefCell::new(values))));
+                        self.push(Value::Instance(blob_id, Rc::new(RefCell::new(values))));
                     }
                     Value::Function(_, block) => {
                         let inner = block.borrow();


### PR DESCRIPTION
Adds in functionality for compiling constant expressions in any order.
There are still some faulty parts, but the idea is there and it
can be looked at for improvements.

Closes #52
