### PR TITLE
unusued variables

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -281,7 +281,7 @@ macro_rules! push_frame {
                     $compiler.error_on_line(
                         e,
                         var.line,
-                        Some(format!("Usage of undefined value: '{}'.", var.name))
+                        Some(format!("Unused value '{}'.", var.name))
                     );
                 }
                 $compiler.panic = false;

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -630,8 +630,8 @@ impl Compiler {
             Value::Function(_, b) if b.borrow().name == name => Some(i),
             _ => None,
         });
-        if res.is_some() {
-            return res.unwrap();
+        if let Some(res) = res {
+            return res;
         }
         let constant = self.add_constant(Value::Nil);
         let line = self.line();

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -914,7 +914,7 @@ impl Compiler {
     }
 
     fn definition_statement(&mut self, name: &str, typ: Type, block: &mut Block) {
-        let mut var = Variable::new(name, true, typ.clone());
+        let var = Variable::new(name, true, typ.clone());
         let slot = self.define(var);
         self.expression(block);
         let constant = self.add_constant(Value::Ty(typ));
@@ -1395,8 +1395,8 @@ impl Compiler {
             .enumerate()
             .map(|(i, (s, f))| (s, (i, f)))
             .collect();
-        let mut main = Variable::new("/main/", false, Type::Void);
-        self.define(main);
+        let main = Variable::new("/main/", false, Type::Void);
+        let _ = self.define(main);
 
         let mut block = Block::new(name, file, 0);
         while self.peek() != Token::EOF {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -394,7 +394,7 @@ impl Compiler {
         &mut self.frames[last]
     }
 
-    /// Marks a variable as read, also marks upvalues.
+    /// Marks a variable as read. Also marks upvalues.
     fn mark_read(&mut self, frame_id: usize, var: &Variable) {
         // Early out
         if var.read {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -856,6 +856,20 @@ mod tests {
         assert_errs!(run_string("a :: B()\n", true, Vec::new()), [ErrorKind::SyntaxError(_, _)]);
     }
 
+    #[test]
+    fn unused_variable() {
+        assert_errs!(run_string("a := 1", true, Vec::new()), [ErrorKind::SyntaxError(1, _)]);
+    }
+
+    #[test]
+    fn unused_upvalue() {
+        assert_errs!(run_string("a := 1\nf :: fn { a = 2 }\nf()", true, Vec::new()), [ErrorKind::SyntaxError(1, _)]);
+    }
+
+    #[test]
+    fn unused_function() {
+        assert_errs!(run_string("a := 1\nf := fn { a }\n", true, Vec::new()), [ErrorKind::SyntaxError(2, _)]);
+    }
 
     macro_rules! test_multiple {
         ($mod:ident, $( $fn:ident : $prog:literal ),+ $( , )? ) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -848,7 +848,7 @@ mod tests {
 
     #[test]
     fn assign_to_constant_upvalue() {
-        assert_errs!(run_string("a :: 2\nq :: fn { a = 2 }\n", true, Vec::new()), [ErrorKind::SyntaxError(_, _)]);
+        assert_errs!(run_string("a :: 2\nq :: fn { a = 2 }\nq()\na", true, Vec::new()), [ErrorKind::SyntaxError(_, _)]);
     }
 
     #[test]
@@ -1043,7 +1043,8 @@ a() <=> 4
         blob,
         simple: "blob A {}",
         instantiate: "blob A {}
-                      a := A()",
+                      a := A()
+                      a",
         field: "blob A { a: int }",
         field_assign: "blob A { a: int }
                        a := A()
@@ -1065,6 +1066,7 @@ a() <=> 4
         blob_infer: "
 blob A { }
 a : A = A()
+a
 ",
     );
 
@@ -1072,8 +1074,8 @@ a : A = A()
         add: "(1, 2, 3, 4) + (4, 3, 2, 1) <=> (5, 5, 5, 5)",
         sub: "(1, -2, 3, -4) - (4, 3, -2, -1) <=> (-3, 1, 1, -5)",
         mul: "(0, 1, 2) * (2, 3, 4) <=> (0, 3, 8)",
-        types: "a: (int, float, int) = (1, 1., 1)",
-        more_types: "a: (str, bool, int) = (\"abc\", true, 1)",
+        types: "a: (int, float, int) = (1, 1., 1)\na",
+        more_types: "a: (str, bool, int) = (\"abc\", true, 1)\na",
     );
 
     test_file!(scoping, "progs/tests/scoping.sy");
@@ -1178,6 +1180,7 @@ a <=> 1
 b := 2
 {
     a <=> 1
+    b <=> 2
 }",
     );
 
@@ -1188,6 +1191,7 @@ a := 0
 b := 99999
 a += 1
 a <=> 1
+b <=> 99999
 ",
 
         simple_sub: "
@@ -1195,6 +1199,7 @@ a := 0
 b := 99999
 a -= 1
 a <=> -1
+b <=> 99999
 ",
 
         strange: "
@@ -1214,6 +1219,7 @@ a <=> -1
         declaration_order,
         blob_simple: "
 a := A()
+a
 
 blob A {
     a: int
@@ -1226,6 +1232,11 @@ b := B()
 c := C()
 b2 := B()
 
+a
+b
+c
+b2
+
 blob A {
     c: C
 }
@@ -1237,6 +1248,7 @@ blob B { }
 blob A { }
 
 a : A = A()
+a
 ",
 
 
@@ -1299,4 +1311,5 @@ q <=> 3
 ",
 
     );
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1023,19 +1023,6 @@ b() <=> 3
 
 a() <=> 4
 ",
-
-        //TODO this tests doesn't terminate in proper time if we print blocks and ops
-        fibonacci: "fibonacci : fn int -> int = fn n: int -> int {
-                      if n == 0 {
-                        ret 0
-                      } else if n == 1 {
-                        ret 1
-                      } else if n < 0 {
-                        <!>
-                      }
-                      ret fibonacci(n - 1) + fibonacci(n - 2)
-                    }
-                    fibonacci(10) <=> 55",
     );
 
     test_multiple!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -908,7 +908,7 @@ f :: fn {
 }
 a
         ";
-        assert_errs!(run_string(prog, true, Vec::new()), [ErrorKind::InvalidProgram, ErrorKind::RuntimeTypeError(_, _)]);
+        assert_errs!(run_string(prog, true, Vec::new()), [ErrorKind::InvalidProgram, ErrorKind::TypeError(_, _)]);
     }
 
     #[test]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -831,15 +831,18 @@ mod tests {
         test_string!(uncallable_type, "
                  f := fn i: int {
                      i()
-                 }",
+                 }
+                 f",
                  [ErrorKind::TypeError(_, _)]);
 
         test_string!(wrong_params, "
-                 f : fn -> int = fn a: int -> int {}",
+                 f : fn -> int = fn a: int -> int {}
+                 f",
                  [ErrorKind::TypeError(_, _), ErrorKind::TypeError(_, _)]);
 
         test_string!(wrong_ret, "
-                 f : fn -> int = fn {}",
+                 f : fn -> int = fn {}
+                 f",
                  [ErrorKind::TypeError(_, _)]);
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -836,7 +836,7 @@ mod tests {
                      i()
                  }
                  f",
-                 [ErrorKind::ValueError(Op::Call(0), _)]);
+                 [ErrorKind::InvalidProgram]);
 
         test_string!(invalid_assign, "a := 1\na = 0.1\na",
                  [ErrorKind::TypeMismatch(Type::Int, Type::Float)]);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -829,7 +829,7 @@ impl VM {
 mod tests {
     mod typing {
         use crate::error::ErrorKind;
-        use crate::{test_string, Op, Type};
+        use crate::{test_string, Type};
 
         test_string!(uncallable_type, "
                  f := fn i: int {


### PR DESCRIPTION
(Added in a bunch of extra stuff, just because it made the PR better... 3432a32 and forrward is relevant.)

Makes it a compilation error if a variable is unused.

I'm unsure how I feel about this currently. It can get annoying,
but I think it's a good help and it needs to be available somehow.
The way to silence the error is to just, read the value on the line
after. It might be better to enforce a naming standard, like Rust?
Or maybe this is a good way to do it, since you don't have to rename
stuff?

Closes #37

Starts work on #63 
