### PR TITLE
destroy format

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -26,16 +26,20 @@ macro_rules! nextable_enum {
 }
 
 macro_rules! error {
-    ($thing:expr, $msg:expr) => {
-        $thing.error(ErrorKind::SyntaxError($thing.line(), $thing.peek()), Some(String::from($msg)))
+    ($thing:expr, $( $msg:expr ),* ) => {
+        {
+            let msg = Some(format!($( $msg ),*).into());
+            let err = ErrorKind::SyntaxError($thing.line(), $thing.peek());
+            $thing.error(err, msg);
+        }
     };
 }
 
 macro_rules! expect {
-    ($thing:expr, $exp_head:pat $( | $exp_rest:pat ),* , $msg:expr) => {
+    ($thing:expr, $exp_head:pat $( | $exp_rest:pat ),* , $( $msg:expr ),*) => {
         match $thing.peek() {
             $exp_head $( | $exp_rest )* => { $thing.eat(); true },
-            _ => { error!($thing, $msg); false } ,
+            _ => { error!($thing, $( $msg ),*); false } ,
         }
     };
 }
@@ -130,7 +134,7 @@ macro_rules! push_frame {
                     $compiler.error_on_line(
                         e,
                         var.line,
-                        Some(format!("Unused value '{}'.", var.name))
+                        Some(format!("Unused value '{}'", var.name))
                     );
                 }
                 $compiler.panic = false;
@@ -161,7 +165,7 @@ macro_rules! push_scope {
                 errors.push((
                     e,
                     var.line,
-                    format!("Usage of undefined value: '{}'.", var.name),)
+                    format!("Unused value: '{}'", var.name),)
                 );
             }
             if var.captured {
@@ -421,7 +425,7 @@ impl Compiler {
                 v.insert(Name::Namespace(path));
             }
             Entry::Occupied(_) => {
-                error!(self, format!("Namespace {} already present.", name));
+                error!(self, "Namespace {} already present", name);
             }
         }
     }
@@ -678,7 +682,7 @@ impl Compiler {
             Token::Bool(b) => { Value::Bool(b) }
             Token::Nil => { Value::Nil }
             Token::String(s) => { Value::String(Rc::from(s)) }
-            _ => { error!(self, "Cannot parse value."); Value::Bool(false) }
+            _ => { error!(self, "Cannot parse value"); Value::Bool(false) }
         };
         let constant = self.add_constant(value);
         add_op(self, block, Op::Constant(constant));
@@ -689,7 +693,7 @@ impl Compiler {
     }
 
     fn tuple(&mut self, block: &mut Block) {
-        expect!(self, Token::LeftParen, "Expected '(' at start of tuple.");
+        expect!(self, Token::LeftParen, "Expected '(' at start of tuple");
 
         let mut num_args = 0;
         let trailing_comma = loop {
@@ -705,7 +709,7 @@ impl Compiler {
                     // ignored and the statement is tried as a grouping instead, even though we
                     // _know_ that this can't be parsed as a grouping either.
                     // Tracked in #100.
-                    error!(self, "Tuples must begin with an element or ')'.");
+                    error!(self, "Tuples must begin with an element or ')'");
                     return;
                 }
                 _ => {
@@ -720,7 +724,7 @@ impl Compiler {
                         },
                         Token::RightParen => {},
                         _ => {
-                            error!(self, "Expected ',' or ')' after tuple element.");
+                            error!(self, "Expected ',' or ')' after tuple element");
                             return;
                         },
                     }
@@ -728,29 +732,29 @@ impl Compiler {
             }
         };
         if num_args == 1 && !trailing_comma {
-            error!(self, "A tuple with 1 element must end with a trailing comma.");
+            error!(self, "A tuple with 1 element must end with a trailing comma");
             return;
         }
 
-        expect!(self, Token::RightParen, "Expected ')' after tuple.");
+        expect!(self, Token::RightParen, "Expected ')' after tuple");
         add_op(self, block, Op::Tuple(num_args));
     }
 
     fn grouping(&mut self, block: &mut Block) {
-        expect!(self, Token::LeftParen, "Expected '(' around expression.");
+        expect!(self, Token::LeftParen, "Expected '(' around expression");
 
         self.expression(block);
 
-        expect!(self, Token::RightParen, "Expected ')' around expression.");
+        expect!(self, Token::RightParen, "Expected ')' around expression");
     }
 
     fn index(&mut self, block: &mut Block) {
-        expect!(self, Token::LeftBracket, "Expected '[' around index.");
+        expect!(self, Token::LeftBracket, "Expected '[' around index");
 
         self.expression(block);
         add_op(self, block, Op::Index);
 
-        expect!(self, Token::RightBracket, "Expected ']' around index.");
+        expect!(self, Token::RightBracket, "Expected ']' around index");
     }
 
     fn unary(&mut self, block: &mut Block) {
@@ -823,7 +827,7 @@ impl Compiler {
 
     fn parse_precedence(&mut self, block: &mut Block, precedence: Prec) {
         if !self.prefix(self.peek(), block) {
-            error!(self, "Invalid expression.");
+            error!(self, "Invalid expression");
         }
 
         while precedence <= self.precedence(self.peek()) {
@@ -881,7 +885,7 @@ impl Compiler {
                     Name::Slot(i, _) => { return *i; },
                     Name::Unknown(i, _) => { return *i; },
                     _ => {
-                        error!(self, format!("Tried to find constant '{}' but it was a namespace.", name));
+                        error!(self, "Tried to find constant '{}' but it was a namespace", name);
                         return 0;
                     }
                 }
@@ -902,7 +906,7 @@ impl Compiler {
                 let slot = if let Name::Unknown(slot, _) = entry.get() {
                     *slot
                 } else {
-                    error!(self, format!("Constant named \"{}\" already has a value.", name));
+                    error!(self, "Constant named \"{}\" already has a value", name);
                     return 0;
                 };
                 entry.insert(Name::Slot(slot, line));
@@ -921,7 +925,7 @@ impl Compiler {
         let slot = self.add_constant(Value::Unknown);
         match self.names_mut().entry(name.clone()) {
             Entry::Occupied(_) => {
-                error!(self, format!("Constant named \"{}\" already has a value.", name));
+                error!(self, "Constant named \"{}\" already has a value", name);
                 0
             },
             Entry::Vacant(entry) => {
@@ -948,7 +952,7 @@ impl Compiler {
                 loop {
                     match self.peek() {
                         Token::EOF => {
-                            error!(self, "Unexpected EOF in function call.");
+                            error!(self, "Unexpected EOF in function call");
                             break;
                         }
                         Token::RightParen => {
@@ -959,7 +963,7 @@ impl Compiler {
                             self.expression(block);
                             arity += 1;
                             if !matches!(self.peek(), Token::RightParen) {
-                                expect!(self, Token::Comma, "Expected ',' after argument.");
+                                expect!(self, Token::Comma, "Expected ',' after argument");
                             }
                         }
                     }
@@ -974,7 +978,7 @@ impl Compiler {
                 loop {
                     match self.peek() {
                         Token::EOF => {
-                            error!(self, "Unexpected EOF in function call.");
+                            error!(self, "Unexpected EOF in function call");
                             break;
                         }
                         Token::Newline => {
@@ -997,7 +1001,7 @@ impl Compiler {
             }
 
             _ => {
-                error!(self, "Invalid function call. Expected '!' or '('.");
+                error!(self, "Invalid function call. Expected '!' or '('");
             }
         }
 
@@ -1006,7 +1010,7 @@ impl Compiler {
 
     // TODO(ed): de-complexify
     fn function(&mut self, block: &mut Block, in_name: Option<&str>) {
-        expect!(self, Token::Fn, "Expected 'fn' at start of function.");
+        expect!(self, Token::Fn, "Expected 'fn' at start of function");
 
         let name = if let Some(name) = in_name {
             String::from(name)
@@ -1027,7 +1031,7 @@ impl Compiler {
                 match self.peek() {
                     Token::Identifier(name) => {
                         self.eat();
-                        expect!(self, Token::Colon, "Expected ':' after parameter name.");
+                        expect!(self, Token::Colon, "Expected ':' after parameter name");
                         if let Ok(typ) = self.parse_type() {
                             args.push(typ.clone());
                             let mut var = Variable::new(&name, true, typ);
@@ -1036,10 +1040,10 @@ impl Compiler {
                                 self.stack_mut()[slot].active = true;
                             }
                         } else {
-                            error!(self, "Failed to parse parameter type.");
+                            error!(self, "Failed to parse parameter type");
                         }
                         if !matches!(self.peek(), Token::Arrow | Token::LeftBrace) {
-                            expect!(self, Token::Comma, "Expected ',' after parameter.");
+                            expect!(self, Token::Comma, "Expected ',' after parameter");
                         }
                     }
                     Token::LeftBrace => {
@@ -1050,12 +1054,12 @@ impl Compiler {
                         if let Ok(typ) = self.parse_type() {
                             return_type = typ;
                         } else {
-                            error!(self, "Failed to parse return type.");
+                            error!(self, "Failed to parse return type");
                         }
                         break;
                     }
                     _ => {
-                        error!(self, "Expected '->' or more paramters in function definition.");
+                        error!(self, "Expected '->' or more paramters in function definition");
                         break;
                     }
                 }
@@ -1113,7 +1117,7 @@ impl Compiler {
             let mut namespace = self.find_namespace(&name).unwrap().clone();
             loop {
                 if self.eat() != Token::Dot {
-                    error!(self, "Expect '.' after namespace.");
+                    error!(self, "Expect '.' after namespace");
                     return;
                 }
                 if let Token::Identifier(field) = self.eat() {
@@ -1130,11 +1134,11 @@ impl Compiler {
                                 .clone();
                         }
                         _ => {
-                            error!(self, "Invalid namespace field.");
+                            error!(self, "Invalid namespace field");
                         }
                     }
                 } else {
-                    error!(self, "Expected fieldname after '.'.");
+                    error!(self, "Expected fieldname after '.'");
                 }
             }
         }
@@ -1165,7 +1169,7 @@ impl Compiler {
                             let string = self.intern_string(String::from(field));
                             add_op(self, block, Op::Get(string));
                         } else {
-                            error!(self, "Expected fieldname after '.'.");
+                            error!(self, "Expected fieldname after '.'");
                             return;
                         }
                     }
@@ -1189,8 +1193,7 @@ impl Compiler {
 
         if let Some(res) = frame.find_local(&var.name).or(frame.find_upvalue(&var.name)) {
             if res.scope == frame.scope {
-                error!(self, format!("Multiple definitions of '{}' in this block.",
-                                     res.name));
+                error!(self, "Multiple definitions of '{}' in this block", res.name);
                 return Err(());
             }
         }
@@ -1206,8 +1209,12 @@ impl Compiler {
     fn definition_statement(&mut self, name: &str, typ: Type, block: &mut Block) {
         if self.frames().len() <= 1 {
             // Global
-            let var = self.frame().find_outer(name)
-                .expect(&format!("Couldn't find variable '{}' during prepass.", name));
+            let var = self.frame().find_outer(name);
+            if var.is_none() {
+                error!(self, "Couldn't find variable '{}' during prepass", name);
+                return;
+            }
+            let var = var.unwrap();
             assert!(var.mutable);
 
             self.expression(block);
@@ -1245,8 +1252,12 @@ impl Compiler {
 
         if self.frames().len() <= 1 {
             // Global
-            let var = self.frame().find_outer(name)
-                .expect(&format!("Couldn't find constant '{}' during prepass.", name));
+            let var = self.frame().find_outer(name);
+            if var.is_none() {
+                error!(self, "Couldn't find constant '{}' during prepass", name);
+                return;
+            }
+            let var = var.unwrap();
             assert!(!var.mutable);
 
             self.expression(block);
@@ -1267,7 +1278,7 @@ impl Compiler {
         let name = match self.eat() {
             Token::Identifier(name) => name,
             _ => {
-                error!(self, format!("Expected identifier in assignment"));
+                error!(self, "Expected identifier in assignment");
                 return;
             }
         };
@@ -1281,7 +1292,7 @@ impl Compiler {
             Token::SlashEqual => Some(Op::Div),
 
             _ => {
-                error!(self, format!("Expected '=' in assignment"));
+                error!(self, "Expected '=' in assignment");
                 return;
             }
         };
@@ -1289,7 +1300,7 @@ impl Compiler {
         if let Some(var) = self.find_variable(&name) {
             if !var.mutable {
                 // TODO(ed): Maybe a better error than "SyntaxError".
-                error!(self, format!("Cannot assign to constant '{}'", var.name));
+                error!(self, "Cannot assign to constant '{}'", var.name);
             }
             if let Some(op) = op {
                 if var.upvalue {
@@ -1309,12 +1320,12 @@ impl Compiler {
                 add_op(self, block, Op::AssignLocal(var.slot));
             }
         } else {
-            error!(self, format!("Using undefined variable {}.", name));
+            error!(self, "Using undefined variable {}", name);
         }
     }
 
     fn scope(&mut self, block: &mut Block) {
-        if !expect!(self, Token::LeftBrace, "Expected '{' at start of block.") {
+        if !expect!(self, Token::LeftBrace, "Expected '{{' at start of block") {
             return;
         }
 
@@ -1324,16 +1335,16 @@ impl Compiler {
                 match self.peek() {
                     Token::Newline => { self.eat(); },
                     Token::RightBrace => { break; },
-                    _ => { error!(self, "Expect newline after statement."); },
+                    _ => { error!(self, "Expect newline after statement"); },
                 }
             }
         });
 
-        expect!(self, Token::RightBrace, "Expected '}' at end of block.");
+        expect!(self, Token::RightBrace, "Expected '}}' at end of block");
     }
 
     fn if_statment(&mut self, block: &mut Block) {
-        expect!(self, Token::If, "Expected 'if' at start of if-statement.");
+        expect!(self, Token::If, "Expected 'if' at start of if-statement");
         self.expression(block);
         let jump = add_op(self, block, Op::Illegal);
         self.scope(block);
@@ -1347,7 +1358,7 @@ impl Compiler {
             match self.peek() {
                 Token::If => self.if_statment(block),
                 Token::LeftBrace => self.scope(block),
-                _ => error!(self, "Epected 'if' or '{' after else."),
+                _ => error!(self, "Epected 'if' or '{{' after else"),
             }
             block.patch(Op::Jmp(block.curr()), else_jmp);
         } else {
@@ -1357,7 +1368,7 @@ impl Compiler {
 
     //TODO de-complexify
     fn for_loop(&mut self, block: &mut Block) {
-        expect!(self, Token::For, "Expected 'for' at start of for-loop.");
+        expect!(self, Token::For, "Expected 'for' at start of for-loop");
 
         push_scope!(self, block, {
             self.frame_mut().push_loop();
@@ -1372,16 +1383,16 @@ impl Compiler {
 
                 (Token::Comma, ..) => {}
 
-                _ => { error!(self, "Expected definition at start of for-loop."); }
+                _ => { error!(self, "Expected definition at start of for-loop"); }
             }
 
-            expect!(self, Token::Comma, "Expect ',' between initalizer and loop expression.");
+            expect!(self, Token::Comma, "Expect ',' between initalizer and loop expression");
 
             let cond = block.curr();
             self.expression(block);
             let cond_out = add_op(self, block, Op::Illegal);
             let cond_cont = add_op(self, block, Op::Illegal);
-            expect!(self, Token::Comma, "Expect ',' between initalizer and loop expression.");
+            expect!(self, Token::Comma, "Expect ',' between initalizer and loop expression");
 
             let inc = block.curr();
             push_scope!(self, block, {
@@ -1443,7 +1454,7 @@ impl Compiler {
                                     self.eat();
                                 }
                             } else {
-                                error!(self, format!("Function type signature contains non-type {:?}.", self.peek()));
+                                error!(self, "Function type signature contains non-type {:?}", self.peek());
                                 return Err(());
                             }
                         }
@@ -1455,7 +1466,7 @@ impl Compiler {
                             break Type::Void;
                         }
                         token => {
-                            error!(self, format!("Function type signature contains non-type {:?}.", token));
+                            error!(self, "Function type signature contains non-type {:?}", token);
                             return Err(());
                         }
                     }
@@ -1475,7 +1486,7 @@ impl Compiler {
                     }
                     if !expect!(self,
                                 Token::Comma,
-                                "Expect comma efter element in tuple.") {
+                                "Expect comma efter element in tuple") {
                         return Err(());
                     }
                 }
@@ -1511,11 +1522,11 @@ impl Compiler {
         let name = if let Token::Identifier(name) = self.eat() {
             name
         } else {
-            error!(self, "Expected identifier after 'blob'.");
+            error!(self, "Expected identifier after 'blob'");
             return;
         };
 
-        expect!(self, Token::LeftBrace, "Expected 'blob' body. AKA '{'.");
+        expect!(self, Token::LeftBrace, "Expected 'blob' body. AKA '{{'");
 
         let mut blob = Blob::new(self.new_blob_id(), &name);
         loop {
@@ -1525,25 +1536,25 @@ impl Compiler {
             let name = if let Token::Identifier(name) = self.eat() {
                 name
             } else {
-                error!(self, "Expected identifier for field.");
+                error!(self, "Expected identifier for field");
                 continue;
             };
 
-            expect!(self, Token::Colon, "Expected ':' after field name.");
+            expect!(self, Token::Colon, "Expected ':' after field name");
 
             let ty = if let Ok(ty) = self.parse_type() {
                 ty
             } else {
-                error!(self, "Failed to parse blob-field type.");
+                error!(self, "Failed to parse blob-field type");
                 continue;
             };
 
             if let Err(_) = blob.add_field(&name, ty) {
-                error!(self, format!("A field named '{}' is defined twice for '{}'", name, blob.name));
+                error!(self, "A field named '{}' is defined twice for '{}'", name, blob.name);
             }
         }
 
-        expect!(self, Token::RightBrace, "Expected '}' after 'blob' body. AKA '}'.");
+        expect!(self, Token::RightBrace, "Expected '}}' after 'blob' body");
 
         let blob = Value::Blob(Rc::new(blob));
         self.named_constant(name, blob);
@@ -1582,7 +1593,7 @@ impl Compiler {
                         let field = if let Token::Identifier(field) = self.eat() {
                             String::from(field)
                         } else {
-                            error!(self, "Expected fieldname after '.'.");
+                            error!(self, "Expected fieldname after '.'");
                             return;
                         };
 
@@ -1618,14 +1629,14 @@ impl Compiler {
                     }
                     _ => {
                         if !self.call_maybe(block) {
-                            error!(self, "Unexpected token when parsing blob-field.");
+                            error!(self, "Unexpected token when parsing blob-field");
                             return;
                         }
                     }
                 }
             }
         } else {
-            error!(self, format!("Cannot find variable '{}'.", name));
+            error!(self, "Cannot find variable '{}'", name);
             return;
         }
     }
@@ -1653,17 +1664,17 @@ impl Compiler {
                 self.eat();
                 self.eat();
                 if let Ok(typ) = self.parse_type() {
-                    expect!(self, Token::Equal, "Expected assignment.");
+                    expect!(self, Token::Equal, "Expected assignment");
                     self.definition_statement(&name, typ, block);
                 } else {
-                    error!(self, format!("Expected type found '{:?}'.", self.peek()));
+                    error!(self, "Expected type found '{:?}'", self.peek());
                 }
             }
 
             (Token::Newline, ..) => {}
 
             (a, b, c, d) => {
-                error!(self, format!("Unknown outer token sequence: {:?} {:?} {:?} {:?}.", a, b, c, d))
+                error!(self, "Unknown outer token sequence: {:?} {:?} {:?} {:?}", a, b, c, d)
             }
         }
     }
@@ -1696,10 +1707,10 @@ impl Compiler {
                 self.eat();
                 self.eat();
                 if let Ok(typ) = self.parse_type() {
-                    expect!(self, Token::Equal, "Expected assignment.");
+                    expect!(self, Token::Equal, "Expected assignment");
                     self.definition_statement(&name, typ, block);
                 } else {
-                    error!(self, format!("Expected type found '{:?}'.", self.peek()));
+                    error!(self, "Expected type found '{:?}'", self.peek());
                 }
             }
 
@@ -1737,7 +1748,7 @@ impl Compiler {
                 let addr = add_op(self, block, Op::Illegal);
                 let stack_size = self.frame().stack.len();
                 if self.frame_mut().add_break(addr, stack_size).is_err() {
-                    error!(self, "Cannot place 'break' outside of loop.");
+                    error!(self, "Cannot place 'break' outside of loop");
                 }
             }
 
@@ -1746,7 +1757,7 @@ impl Compiler {
                 let addr = add_op(self, block, Op::Illegal);
                 let stack_size = self.frame().stack.len();
                 if self.frame_mut().add_continue(addr, stack_size).is_err() {
-                    error!(self, "Cannot place 'continue' outside of loop.");
+                    error!(self, "Cannot place 'continue' outside of loop");
                 }
             }
 
@@ -1818,7 +1829,7 @@ impl Compiler {
                         let var = Variable::new(&name, is_mut, ty);
                         let _ = self.define(var).unwrap();
                     } else {
-                        error!(self, format!("Failed to parse type global '{}'.", name));
+                        error!(self, "Failed to parse type global '{}'", name);
                     }
                 }
 
@@ -1839,8 +1850,7 @@ impl Compiler {
 
                 (a, b, c) => {
                     section.faulty = true;
-                    let msg = format!("Unknown outer token sequence: {:?} {:?} {:?}. Expected 'use', function, blob or variable.", a, b, c);
-                    error!(self, msg);
+                    error!(self, "Unknown outer token sequence: {:?} {:?} {:?}. Expected 'use', function, blob or variable", a, b, c);
                 }
             }
         }
@@ -1860,7 +1870,7 @@ impl Compiler {
             while !matches!(self.peek(), Token::EOF | Token::Use) {
                 self.outer_statement(&mut block);
                 expect!(self, Token::Newline | Token::EOF,
-                        "Expect newline or EOF after expression.");
+                        "Expect newline or EOF after expression");
             }
         }
         block.ty = Type::Function(Vec::new(), Box::new(Type::Void));
@@ -1870,7 +1880,7 @@ impl Compiler {
                 if let Name::Unknown(_, line) = kind {
                     Some((ErrorKind::SyntaxError(*line, Token::Identifier(name.clone())),
                     *line,
-                    format!("Usage of undefined value: '{}'.", name,)))
+                    format!("Usage of undefined value: '{}'", name,)))
                 } else {
                     None
                 }) .collect();
@@ -1891,7 +1901,7 @@ impl Compiler {
         for var in self.frames_mut().pop().unwrap().stack.iter().skip(1) {
             if !(var.read || var.upvalue) {
                 let e = ErrorKind::SyntaxError(var.line, Token::Identifier(var.name.clone()));
-                let m = format!("Unused value '{}'.", var.name);
+                let m = format!("Unused value '{}'", var.name);
                 self.error_on_line(e, var.line, Some(m));
             }
             self.panic = false;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -15,8 +15,11 @@ macro_rules! error {
     ( $thing:expr, $kind:expr) => {
         return Err($thing.error($kind, None));
     };
-    ( $thing:expr, $kind:expr, $msg:expr) => {
-        return Err($thing.error($kind, Some(String::from($msg))));
+    ( $thing:expr, $kind:expr, $( $msg:expr ),*) => {
+        {
+            let msg = Some(format!($( $msg ),*).into());
+            return Err($thing.error($kind, msg));
+        }
     };
 }
 
@@ -283,7 +286,7 @@ impl VM {
                     },
                     value => error!(self,
                         ErrorKind::ValueError(op, vec![value.clone()]),
-                        format!("Not a function {:?}.", value)),
+                        "Not a function {:?}", value),
                 };
                 self.constants[slot] = constant;
             }
@@ -452,7 +455,7 @@ impl VM {
                         let extern_func = self.extern_functions[slot];
                         let res = match extern_func(&self.stack[new_base+1..], false) {
                             Ok(value) => value,
-                            Err(ek) => error!(self, ek, "Failed in external function."),
+                            Err(ek) => error!(self, ek, "Failed in external function"),
                         };
                         self.stack.truncate(new_base);
                         self.push(res);
@@ -561,8 +564,8 @@ impl VM {
                             if block.borrow().needs_linking() {
                                 error!(self,
                                        ErrorKind::InvalidProgram,
-                                       format!("Calling function '{}' before all captured variables are declared.",
-                                               block.borrow().name));
+                                       "Calling function '{}' before all captured variables are declared",
+                                               block.borrow().name);
                             }
 
                             let mut types = Vec::new();
@@ -617,7 +620,7 @@ impl VM {
                     let expected = Type::from(&value);
                     if ty != &expected {
                         error!(self, ErrorKind::TypeMismatch(expected, ty.clone()),
-                               "Types of field and variable do not match.");
+                               "Types of field and variable do not match");
                     }
                 } else {
                     error!(self, ErrorKind::UnknownField(inst, field.clone()));
@@ -638,7 +641,7 @@ impl VM {
                 let up = self.pop().into();
                 if var != up {
                     error!(self, ErrorKind::TypeMismatch(up, var),
-                           "Captured varibles type doesn't match upvalue.");
+                           "Captured varibles type doesn't match upvalue");
                 }
             }
 
@@ -648,7 +651,7 @@ impl VM {
                 let other = Type::from(self.pop());
                 if curr != other {
                     error!(self, ErrorKind::TypeMismatch(curr, other),
-                           "Cannot assign to different type.");
+                           "Cannot assign to different type");
                 }
             }
 
@@ -659,7 +662,7 @@ impl VM {
                 if Type::from(&a) != *ret {
 
                     error!(self, ErrorKind::TypeMismatch(ret.clone(), a.into()),
-                           "Value does not match return type.");
+                           "Value does not match return type");
                 }
             }
 
@@ -679,7 +682,7 @@ impl VM {
                         if top_type != Type::Unknown => {}
                     (a, b) if a != &b => {
                         error!(self, ErrorKind::TypeMismatch(a.clone(), b.clone()),
-                               "Cannot assign mismatching types.");
+                               "Cannot assign mismatching types");
                     }
                     _ => {}
                 }
@@ -716,7 +719,7 @@ impl VM {
                     value => {
                         error!(self,
                             ErrorKind::TypeError(op, vec![Type::from(&value)]),
-                            format!("Cannot link non-function {:?}.", value));
+                            "Cannot link non-function {:?}", value);
                     }
                 };
             }


### PR DESCRIPTION
Remove all instances of format! from error messages. Making the codebase
more ergonomic. Also some smaller drivebys where the code reported
unnessecary or missleading errors.
