### PR TITLE
Op::Force

### DIFF
--- a/progs/tests/force/call.sy
+++ b/progs/tests/force/call.sy
@@ -1,0 +1,8 @@
+f :: fn -> int | bool {
+    ret 1
+}
+
+start :: fn {
+    a: !int = f!
+    a <=> 1
+}

--- a/progs/tests/force/faulty.sy
+++ b/progs/tests/force/faulty.sy
@@ -1,7 +1,0 @@
-start :: fn {
-    a :: (1, "not", "an", "int")
-    b: int = a[0]
-    b
-}
-
-// errors: [ErrorKind::TypeMismatch(Type::Int, _)]

--- a/progs/tests/force/faulty.sy
+++ b/progs/tests/force/faulty.sy
@@ -1,0 +1,7 @@
+start :: fn {
+    a :: (1, "not", "an", "int")
+    b: int = a[0]
+    b
+}
+
+// errors: [ErrorKind::TypeMismatch(Type::Int, _)]

--- a/progs/tests/force/faulty_call.sy
+++ b/progs/tests/force/faulty_call.sy
@@ -1,0 +1,10 @@
+f :: fn -> int | bool {
+    ret 1
+}
+
+start :: fn {
+    a: int = f!
+    a <=> 1
+}
+
+// errors: [ErrorKind::TypeMismatch(Type::Int, _)]

--- a/progs/tests/force/faulty_tuple.sy
+++ b/progs/tests/force/faulty_tuple.sy
@@ -1,0 +1,7 @@
+start :: fn {
+    a :: (1, "not", "an", "int")
+    b: int = a[0]
+    b
+}
+
+// errors: [ErrorKind::TypeMismatch(Type::Int, _)]

--- a/progs/tests/force/simple.sy
+++ b/progs/tests/force/simple.sy
@@ -1,0 +1,5 @@
+start :: fn {
+    a :: (1, "not", "an", "int")
+    b: !int = a[0]
+    b
+}

--- a/progs/tests/force/union_call.sy
+++ b/progs/tests/force/union_call.sy
@@ -1,0 +1,14 @@
+f :: fn a: int -> int | bool | str {
+    if a == 0 {
+        ret 1
+    }
+    ret true
+}
+
+start :: fn {
+    a: !int | bool = f! 0
+    if a != 1 {
+        <!>
+    }
+    a <=> 1
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -625,11 +625,11 @@ pub enum Op {
     /// {A} - AssignUpvalue(0) - {}
     AssignUpvalue(usize),
 
-    /// A helper instruction for the typechecker,
-    /// *makes sure* the top value on the stack
-    /// is of the given type, and is ment to signal
+    /// A helper instruction for the type checker.
+    /// *Makes sure* that the top value on the stack
+    /// is of the given type, and is meant to signal
     /// that the "variable" is added.
-    /// (The type is looked up in the constants vector)
+    /// (The type is looked up in the constants vector.)
     ///
     /// Does not affect the stack.
     Define(usize),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -626,13 +626,21 @@ pub enum Op {
     AssignUpvalue(usize),
 
     /// A helper instruction for the typechecker,
-    /// makes sure the top value on the stack
+    /// *makes sure* the top value on the stack
     /// is of the given type, and is ment to signal
     /// that the "variable" is added.
     /// (The type is looked up in the constants vector)
     ///
     /// Does not affect the stack.
     Define(usize),
+    /// A helper instruction for the typechecker,
+    /// *assumes* top value on the stack
+    /// is of the given type. Usefull for helping the
+    /// type system where it just can't do it.
+    /// (The type is looked up in the constants vector)
+    ///
+    /// Does not affect the stack.
+    Force(usize),
 
     /// Links the upvalues for the given constant
     /// function. This updates the constant stack.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -530,6 +530,8 @@ impl VM {
 
             Op::Define(_) => {}
 
+            Op::Force(_) => {}
+
             Op::Call(num_args) => {
                 let new_base = self.stack.len() - 1 - num_args;
                 match self.stack[new_base].clone() {
@@ -815,6 +817,12 @@ impl VM {
                         );
                     }
                 }
+            }
+
+            Op::Force(ty) => {
+                let ty = Value::from(self.ty(ty));
+                self.pop();
+                self.push(ty);
             }
 
             Op::Link(slot) => {


### PR DESCRIPTION
Adds in the Op::Force, that can be used

```sylt
a :: (1, true)
b: !int = a[0]
```

Allows a lot of mischeif but it gives a way to compile all valid programs.

Closes #107 