### PR TITLE
ignore ops that cannot possible do anything

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -984,7 +984,26 @@ impl Block {
     }
 
     fn add(&mut self, op: Op, token_position: usize) -> usize {
-        let len = self.curr();
+        let mut len = self.curr();
+        if matches!(op, Op::Pop) && len > 1 {
+            len -= 1;
+            match self.ops.last().unwrap() {
+                Op::Copy(n) => {
+                    if *n == 1 {
+                        self.ops.pop();
+                        return len - 1;
+                    } else {
+                        self.ops[len] = Op::Copy(*n - 1);
+                        return len;
+                    }
+                }
+                Op::Constant(_) | Op::ReadLocal(_) | Op::ReadUpvalue(_) => {
+                    self.ops.pop();
+                    return len - 1;
+                }
+                _ => {}
+            }
+        }
         self.add_line(token_position);
         self.ops.push(op);
         len


### PR DESCRIPTION
Number of instructions for the entire test-suite:
New: 3194
Old: 3266

We save around 70 instructions, for the ~100 testcases, it's a small optimization but I think it's worth it. But it's honestly not a big deal. I mostly wanted to check my thinking.
