### PR TITLE
Passing blobs

### DIFF
--- a/progs/tests/blob/cluster.sy
+++ b/progs/tests/blob/cluster.sy
@@ -2,7 +2,7 @@ A :: blob { a: int }
 
 start :: fn {
 
-    a := A(0)
+    a := A { a: 0 }
     a.a = 0
     a.a += 1
     a.a <=> 1

--- a/progs/tests/blob/cluster.sy
+++ b/progs/tests/blob/cluster.sy
@@ -2,7 +2,7 @@ A :: blob { a: int }
 
 start :: fn {
 
-    a := A { a: 0 }
+    a := A! { a: 0 }
     a.a = 0
     a.a += 1
     a.a <=> 1

--- a/progs/tests/blob/complex.sy
+++ b/progs/tests/blob/complex.sy
@@ -11,10 +11,10 @@ A :: blob {
 B :: blob { }
 
 start :: fn {
-    c := C()
-    a := A(c)
-    b := B()
-    b2 := B()
+    c := C {}
+    a := A { c: c }
+    b := B {}
+    b2 := B {}
 
     a
     b

--- a/progs/tests/blob/complex.sy
+++ b/progs/tests/blob/complex.sy
@@ -11,10 +11,10 @@ A :: blob {
 B :: blob { }
 
 start :: fn {
-    c := C {}
-    a := A { c: c }
-    b := B {}
-    b2 := B {}
+    c := C! {}
+    a := A! { c: c }
+    b := B! {}
+    b2 := B! {}
 
     a
     b

--- a/progs/tests/blob/faulty_num_arguments.sy
+++ b/progs/tests/blob/faulty_num_arguments.sy
@@ -4,8 +4,8 @@ A :: blob {
 }
 
 start :: fn {
-    a :: A(1, 2, 3)
+    a :: A { a: 1, b: 2, c: 3 }
     a
 }
 
-// error: #ArgumentCount(2, 3)
+// error: #UnknownField(_, _)

--- a/progs/tests/blob/faulty_num_arguments.sy
+++ b/progs/tests/blob/faulty_num_arguments.sy
@@ -4,7 +4,7 @@ A :: blob {
 }
 
 start :: fn {
-    a :: A { a: 1, b: 2, c: 3 }
+    a :: A! { a: 1, b: 2, c: 3 }
     a
 }
 

--- a/progs/tests/blob/field_assign.sy
+++ b/progs/tests/blob/field_assign.sy
@@ -1,6 +1,6 @@
 A :: blob { a: int }
 
 start :: fn {
-    a := A(1)
+    a := A { a: 1 }
     a.a = 2
 }

--- a/progs/tests/blob/field_assign.sy
+++ b/progs/tests/blob/field_assign.sy
@@ -1,6 +1,6 @@
 A :: blob { a: int }
 
 start :: fn {
-    a := A { a: 1 }
+    a := A! { a: 1 }
     a.a = 2
 }

--- a/progs/tests/blob/field_get.sy
+++ b/progs/tests/blob/field_get.sy
@@ -1,6 +1,6 @@
 A :: blob { a: int }
 start :: fn {
-    a := A { a: 1 }
+    a := A! { a: 1 }
     a.a <=> 1
     1 <=> a.a
 }

--- a/progs/tests/blob/field_get.sy
+++ b/progs/tests/blob/field_get.sy
@@ -1,6 +1,6 @@
 A :: blob { a: int }
 start :: fn {
-    a := A(1)
+    a := A { a: 1 }
     a.a <=> 1
     1 <=> a.a
 }

--- a/progs/tests/blob/infer.sy
+++ b/progs/tests/blob/infer.sy
@@ -1,6 +1,6 @@
 A :: blob { }
 start :: fn {
 
-    a : A = A()
+    a : A = A!
     a
 }

--- a/progs/tests/blob/instantiate.sy
+++ b/progs/tests/blob/instantiate.sy
@@ -1,5 +1,5 @@
 A :: blob {}
 start :: fn {
-    a := A()
+    a := A!
     a
 }

--- a/progs/tests/blob/multiple_fields.sy
+++ b/progs/tests/blob/multiple_fields.sy
@@ -4,7 +4,7 @@ A :: blob {
 }
 
 start :: fn {
-    a := A(1, 2)
+    a := A { a: 1, b: 2 }
     a.a + a.b <=> 3
     3 <=> a.a + a.b
 }

--- a/progs/tests/blob/multiple_fields.sy
+++ b/progs/tests/blob/multiple_fields.sy
@@ -4,7 +4,7 @@ A :: blob {
 }
 
 start :: fn {
-    a := A { a: 1, b: 2 }
+    a := A! { a: 1, b: 2 }
     a.a + a.b <=> 3
     3 <=> a.a + a.b
 }

--- a/progs/tests/blob/non_null_fields_faulty.sy
+++ b/progs/tests/blob/non_null_fields_faulty.sy
@@ -1,0 +1,11 @@
+A :: blob {
+    a: int
+}
+
+start :: fn {
+    a := A!
+    print a.a
+}
+
+// error: #FieldTypeMismatch(_, _, _, _)
+// error: #TypeError(_, _)

--- a/progs/tests/blob/null_fields.sy
+++ b/progs/tests/blob/null_fields.sy
@@ -1,0 +1,8 @@
+A :: blob {
+    a: int?
+}
+
+start :: fn {
+    a := A!
+    print a.a
+}

--- a/progs/tests/blob/null_fields_faulty.sy
+++ b/progs/tests/blob/null_fields_faulty.sy
@@ -1,0 +1,13 @@
+A :: blob {
+}
+
+B :: blob {
+    a: int?
+}
+
+start :: fn {
+    a : !B = A!
+    print a.a
+}
+
+// error: #UnknownField(_, _)

--- a/progs/tests/blob/simple.sy
+++ b/progs/tests/blob/simple.sy
@@ -3,6 +3,6 @@ A :: blob {
 }
 
 start :: fn {
-    a := A { a: 1 }
+    a := A! { a: 1 }
     a
 }

--- a/progs/tests/blob/simple.sy
+++ b/progs/tests/blob/simple.sy
@@ -3,8 +3,6 @@ A :: blob {
 }
 
 start :: fn {
-
-    a := A(1)
+    a := A { a: 1 }
     a
-
 }

--- a/progs/tests/faulty_list_index_assign.sy
+++ b/progs/tests/faulty_list_index_assign.sy
@@ -6,7 +6,7 @@ start :: fn {
     a :: [1]
     a[0] = "fail"
 
-    q :: Q([4])
+    q :: Q! { a: [4] }
     q.a[0] = "fail"
 }
 

--- a/progs/tests/list_indexing.sy
+++ b/progs/tests/list_indexing.sy
@@ -9,7 +9,7 @@ start :: fn {
     push(a, 3)
     a[1] <=> 4
 
-    q :: Q([4])
+    q :: Q! { a: [4] }
     push(q.a, 3)
     q.a[1] = 1
     push(q.a, 3)

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1014,15 +1014,18 @@ impl Compiler {
     }
 
     fn call_maybe(&mut self, block: &mut Block) -> bool {
-        match self.peek() {
-            Token::Bang | Token::LeftParen => self.call(block),
-            Token::LeftBrace => self.blob_initalizer(block),
+        match self.peek_four() {
+            (Token::Bang, Token::LeftBrace, ..) => {
+                self.blob_initalizer(block)
+            }
+            (Token::Bang, ..) | (Token::LeftParen, ..) => self.call(block),
             _ => { return false; }
         }
         return true;
     }
 
     fn blob_initalizer(&mut self, block: &mut Block) {
+        expect!(self, Token::Bang, "Exptected '!' at start of blob initalizer");
         expect!(self, Token::LeftBrace, "Exptected '{{' at start of blob initalizer");
         let mut num_fields = 0;
         loop {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1027,7 +1027,7 @@ impl Compiler {
         let mut num_fields = 0;
         loop {
             match self.peek() {
-                Token::Newline => {
+                Token::Newline | Token::Comma => {
                     self.eat();
                 }
                 Token::Identifier(field) => {
@@ -1037,7 +1037,9 @@ impl Compiler {
                     add_op(self, block, Op::Constant(field));
                     expect!(self, Token::Colon, "Exptected ':' after field name");
                     self.expression(block);
-                    expect!(self, Token::Newline, "Exptected 'CR' after field expression");
+                    if !matches!(self.peek(), Token::Newline | Token::Comma | Token::RightBrace) {
+                        syntax_error!(self, "Trash at end of line");
+                    }
                 }
                 Token::RightBrace => {
                     break;

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1016,7 +1016,7 @@ impl Compiler {
     fn call_maybe(&mut self, block: &mut Block) -> bool {
         match self.peek_four() {
             (Token::Bang, Token::LeftBrace, ..) => {
-                self.blob_initalizer(block)
+                self.blob_initializer(block)
             }
             (Token::Bang, ..) | (Token::LeftParen, ..) => self.call(block),
             _ => { return false; }
@@ -1024,9 +1024,9 @@ impl Compiler {
         return true;
     }
 
-    fn blob_initalizer(&mut self, block: &mut Block) {
-        expect!(self, Token::Bang, "Exptected '!' at start of blob initalizer");
-        expect!(self, Token::LeftBrace, "Exptected '{{' at start of blob initalizer");
+    fn blob_initializer(&mut self, block: &mut Block) {
+        expect!(self, Token::Bang, "Expected '!' at start of blob initializer");
+        expect!(self, Token::LeftBrace, "Expected '{{' at start of blob initializer");
         let mut num_fields = 0;
         loop {
             match self.peek() {
@@ -1038,7 +1038,7 @@ impl Compiler {
                     num_fields += 1;
                     let field = self.add_constant(Value::Field(field));
                     add_op(self, block, Op::Constant(field));
-                    expect!(self, Token::Colon, "Exptected ':' after field name");
+                    expect!(self, Token::Colon, "Expected ':' after field name");
                     self.expression(block);
                     if !matches!(self.peek(), Token::Newline | Token::Comma | Token::RightBrace) {
                         syntax_error!(self, "Trash at end of line");
@@ -1048,13 +1048,13 @@ impl Compiler {
                     break;
                 }
                 _ => {
-                    syntax_error!(self, "Expected field name in initalizer");
+                    syntax_error!(self, "Expected field name in initializer");
                     break;
                 }
             }
         }
         add_op(self, block, Op::Call(num_fields * 2));
-        expect!(self, Token::RightBrace, "Exptected '}}' after blob initalizer");
+        expect!(self, Token::RightBrace, "Expected '}}' after blob initializer");
     }
 
     fn call(&mut self, block: &mut Block) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,7 @@ fn file_line_display(file: &Path, line: Option<usize>) -> String {
 
 #[derive(Debug, Clone)]
 pub enum RuntimeError {
+    FieldTypeMismatch(String, String, Type, Type),
     TypeError(Op, Vec<Type>),
     TypeMismatch(Type, Type),
     CannotInfer(Type, Type),
@@ -167,6 +168,9 @@ impl fmt::Display for Error {
 impl fmt::Display for RuntimeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            RuntimeError::FieldTypeMismatch(obj, field, a, b) => {
+                write!(f, "Field {}.{} expected {:?} but got {:?}", obj, field, a, b)
+            }
             RuntimeError::TypeError(op, types) => {
                 let types = types
                     .iter()

--- a/src/sectionizer.rs
+++ b/src/sectionizer.rs
@@ -72,29 +72,18 @@ pub fn sectionize(path: &Path) -> Result<Vec<Section>, Vec<Error>> {
                 }
 
                 (Some((Token::LeftBrace, _)), ..) => {
-                    let mut blocks = 1;
+                    let mut blocks = 0;
                     loop {
-                        curr += 1;
                         match tokens.get(curr) {
-                            Some((Token::LeftBrace, _)) => {
-                                blocks += 1;
-                            }
-
-                            Some((Token::RightBrace, _)) => {
-                                curr += 1;
-                                blocks -= 1;
-                                if blocks <= 0 {
-                                    curr -= 1;
-                                    break;
-                                }
-                            }
-
-                            None => {
-                                break;
-                            }
-
+                            Some((Token::LeftBrace, _)) => { blocks += 1; }
+                            Some((Token::RightBrace, _)) => { blocks -= 1; }
+                            None => { break; }
                             _ => {}
                         }
+                        if blocks == 0 {
+                            break;
+                        }
+                        curr += 1;
                     }
                     false
                 }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -598,8 +598,8 @@ impl VM {
                                         return Err(RuntimeError::FieldTypeMismatch(
                                                 blob.name.clone(),
                                                 field.clone(),
-                                                t.clone(),
                                                 ty.clone(),
+                                                t.clone(),
                                         ))
                                     }
                                     (None, ty) if ty.fits(&Type::Void) => {}
@@ -607,8 +607,8 @@ impl VM {
                                         return Err(RuntimeError::FieldTypeMismatch(
                                                 blob.name.clone(),
                                                 field.clone(),
-                                                Type::Void,
                                                 ty.clone(),
+                                                Type::Void,
                                         ));
                                     }
                                 }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -583,11 +583,9 @@ impl VM {
                                         ));
                                     }
                                     None => {
-                                        return Err(RuntimeError::FieldTypeMismatch(
+                                        return Err(RuntimeError::UnknownField(
                                                 blob.name.clone(),
                                                 field.clone(),
-                                                Type::Void,
-                                                ty.clone(),
                                         ));
                                     }
                                 }
@@ -605,10 +603,12 @@ impl VM {
                                         ))
                                     }
                                     (None, _) => {
-                                        return Err(RuntimeError::UnknownField(
+                                        return Err(RuntimeError::FieldTypeMismatch(
                                                 blob.name.clone(),
                                                 field.clone(),
-                                        ))
+                                                Type::Void,
+                                                ty.clone(),
+                                        ));
                                     }
                                 }
                             }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -573,13 +573,13 @@ impl VM {
 
                             for (field, ty) in values.iter() {
                                 match blob.fields.get(field) {
-                                    Some(given_ty) if ty == given_ty => {}
+                                    Some(given_ty) if given_ty.fits(ty) => {}
                                     Some(given_ty) => {
                                         return Err(RuntimeError::FieldTypeMismatch(
                                                 blob.name.clone(),
                                                 field.clone(),
-                                                given_ty.clone(),
                                                 ty.clone(),
+                                                given_ty.clone(),
                                         ));
                                     }
                                     None => {
@@ -593,16 +593,17 @@ impl VM {
 
                             for (field, ty) in blob.fields.iter() {
                                 match (values.get(field), ty) {
-                                    (Some(ty), t) if ty == t => {}
-                                    (Some(ty), t) => {
+                                    (Some(t), ty) if ty.fits(t) => {}
+                                    (Some(t), ty) => {
                                         return Err(RuntimeError::FieldTypeMismatch(
                                                 blob.name.clone(),
                                                 field.clone(),
-                                                ty.clone(),
                                                 t.clone(),
+                                                ty.clone(),
                                         ))
                                     }
-                                    (None, _) => {
+                                    (None, ty) if ty.fits(&Type::Void) => {}
+                                    (None, ty) => {
                                         return Err(RuntimeError::FieldTypeMismatch(
                                                 blob.name.clone(),
                                                 field.clone(),

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -567,7 +567,7 @@ impl VM {
                                     if let Type::Field(f) = &b[0] {
                                         (f.clone(), b[1].clone())
                                     } else {
-                                        unreachable!("Got {:?} when I expected field", b[0]);
+                                        unreachable!("Got {:?}, expected field", b[0]);
                                     }
                                 }).collect::<HashMap<String, Type>>();
 
@@ -941,4 +941,3 @@ mod op {
         }
     }
 }
-

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -640,6 +640,9 @@ impl VM {
                             })
                             .collect::<HashMap<_, _>>();
                         self.stack.truncate(new_base);
+                        for name in blob.fields.keys() {
+                            values.entry(name.clone()).or_insert(Value::Nil);
+                        }
                         values.insert("_id".to_string(), Value::Int(blob.id as i64));
                         values.insert("_name".to_string(), Value::String(Rc::new(blob.name.clone())));
                         self.push(Value::Instance(blob, Rc::new(RefCell::new(values))));

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -411,9 +411,9 @@ impl VM {
                 match inst {
                     Value::Instance(ty, values) => {
                         let field = self.string(field);
-                        match ty.fields.get(field) {
-                            Some((slot, _)) => {
-                                self.push(values.borrow()[*slot].clone());
+                        match (*values).borrow().get(field) {
+                            Some(value) => {
+                                self.push(value.clone());
                             }
                             _ => {
                                 let err = Err(self.error(
@@ -438,18 +438,11 @@ impl VM {
                 let (inst, value) = self.poppop();
                 match inst {
                     Value::Instance(ty, values) => {
-                        let field = self.string(field);
-                        match ty.fields.get(field) {
-                            Some((slot, _)) => {
-                                values.borrow_mut()[*slot] = value;
-                            }
-                            _ => {
-                                error!(
-                                    self,
-                                    RuntimeError::UnknownField(ty.name.clone(), field.clone())
-                                );
-                            }
-                        };
+                        let field_name = self.string(field).clone();
+                        if !(*ty).fields.contains_key(&field_name) {
+                            error!(self, RuntimeError::UnknownField(ty.name.to_string(), field_name));
+                        }
+                        (*values).borrow_mut().insert(field_name, value);
                     }
                     inst => {
                         error!(
@@ -636,8 +629,19 @@ impl VM {
                 let new_base = self.stack.len() - 1 - num_args;
                 match self.stack[new_base].clone() {
                     Value::Blob(blob) => {
-                        let values = self.stack.split_off(new_base + 1);
-                        self.pop();
+                        let mut values = self.stack[new_base+1..]
+                            .chunks_exact(2)
+                            .map(|b| {
+                                if let Value::Field(name) = &b[0] {
+                                    (name.clone(), b[1].clone())
+                                } else {
+                                    panic!("Expected Field but got {:?} for field names", b[0]);
+                                }
+                            })
+                            .collect::<HashMap<_, _>>();
+                        self.stack.truncate(new_base);
+                        values.insert("_id".to_string(), Value::Int(blob.id as i64));
+                        values.insert("_name".to_string(), Value::String(Rc::new(blob.name.clone())));
                         self.push(Value::Instance(blob, Rc::new(RefCell::new(values))));
                     }
                     Value::Function(_, block) => {


### PR DESCRIPTION
Closes #18
I did some things... Erm... Blobs are now hashmaps, which play nice with rust. I've tought of some speed improvements with internging strings for field access. But they might be hard with rust interop.

- Make instances into hashmaps
- New initlizer syntax for blobs
- Simplify the sectionizer code
- Allow one-line initlizers
- Fix type error
- Fix all blob-tests
- Rework the initlizer syntax
- Allow nullable fields
- Test for nulling non-null fields
- Correct type error messages
