### PR TITLE
Debug printing of constants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -881,17 +881,23 @@ impl Block {
         0
     }
 
-    pub fn debug_print(&self) {
+    pub fn debug_print(&self, constants: Option<&[Value]>) {
         println!("     === {} ===", self.name.blue());
         for (i, s) in self.ops.iter().enumerate() {
             println!(
-                "{}{}",
+                "{}{:05} {:?}{}",
                 if self.line_offsets.contains_key(&i) {
                     format!("{:5} ", self.line_offsets[&i].blue())
                 } else {
                     format!("    {} ", "|".blue())
                 },
-                format!("{:05} {:?}", i.red(), s)
+                i.red(),
+                s,
+                if let (Op::Constant(c), Some(constants)) = (s, constants) {
+                    format!("    => {:?}", &constants[*c])
+                } else {
+                    "".to_string()
+                }
             );
         }
         println!();

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -73,7 +73,7 @@ fn typecheck_block(block: Rc<RefCell<Block>>, prog: &Prog, args: &Args) -> Vec<E
             "TYPECHECKING".purple(),
             block.borrow().name
         );
-        block.borrow().debug_print();
+        block.borrow().debug_print(Some(&prog.constants));
     }
 
     let mut vm = VM::new(&block);
@@ -97,7 +97,6 @@ fn typecheck_block(block: Rc<RefCell<Block>>, prog: &Prog, args: &Args) -> Vec<E
             "DONE".purple(),
             block.borrow().name
         );
-        block.borrow().debug_print();
     }
 
     errors

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -168,7 +168,7 @@ impl VM {
         self.print_stack();
         println!("\n");
         self.print_stacktrace();
-        self.frame().block.borrow().debug_print();
+        self.frame().block.borrow().debug_print(Some(&self.constants));
         println!(
             "    ip: {}, line: {}\n",
             self.frame().ip.blue(),
@@ -656,7 +656,7 @@ impl VM {
 
                         #[cfg(debug_assertions)]
                         if self.print_bytecode {
-                            inner.debug_print();
+                            inner.debug_print(Some(&self.constants));
                         }
                         self.frames.push(Frame {
                             stack_offset: new_base,
@@ -750,7 +750,7 @@ impl VM {
     pub fn run(&mut self) -> Result<OpResult, Error> {
         if self.print_bytecode {
             println!("\n    [[{}]]\n", "RUNNING".red());
-            self.frame().block.borrow().debug_print();
+            self.frame().block.borrow().debug_print(Some(&self.constants));
         }
 
         loop {


### PR DESCRIPTION
Values are printed `=> EXPR`, after a constant instruction. It's great!
I skipped it deliberatly for the running instructions, since you can look at the stack the step after. :3
(And it was annoying to implement so ceebs)
