### PR TITLE
Allow globals in multiple files

### DIFF
--- a/progs/tests/constant/declaration_order_wrong.sy
+++ b/progs/tests/constant/declaration_order_wrong.sy
@@ -5,4 +5,4 @@ start :: fn {
     a <=> b + 1
 }
 
-// error: @1
+// error: #InvalidProgram

--- a/progs/tests/import/_constants.sy
+++ b/progs/tests/import/_constants.sy
@@ -1,0 +1,14 @@
+
+_one :: 1
+one :: fn -> int {
+    ret _one
+}
+
+_two := 2.0
+two :: fn -> float {
+    ret _two
+}
+
+three :: fn -> int {
+    ret _one + _one + _one
+}

--- a/progs/tests/import/_constants2.sy
+++ b/progs/tests/import/_constants2.sy
@@ -1,0 +1,5 @@
+
+_zero := 0
+zero :: fn -> int {
+    ret _zero
+}

--- a/progs/tests/import/constant_in_other_file.sy
+++ b/progs/tests/import/constant_in_other_file.sy
@@ -1,0 +1,7 @@
+use _constants
+
+start :: fn {
+    _constants.one() <=> 1
+    _constants.two() <=> 2.0
+    _constants.three() <=> 3
+}

--- a/progs/tests/import/constants_in_many_files.sy
+++ b/progs/tests/import/constants_in_many_files.sy
@@ -1,0 +1,8 @@
+use _constants
+use _constants2
+
+
+start :: fn {
+    _constants2.zero() <=> 0
+    _constants.one() <=> 1
+}

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -54,7 +54,7 @@ macro_rules! push_frame {
             $compiler.frames_mut().push(Frame::new());
 
             // Return value stored as a variable
-            let var = Variable::new("", true, Type::Unknown);
+            let var = Variable::new("/frame", true, Type::Unknown);
             $compiler.define(var).unwrap();
 
             $code

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -798,6 +798,21 @@ pub enum Op {
     /// {A} - AssignUpvalue(0) - {}
     AssignUpvalue(usize),
 
+    /// Reads the global, and adds it
+    /// to the top of the stack.
+    ///
+    /// Constants are stored at the bottom
+    /// of the stack and initalized when
+    /// the program starts.
+    ///
+    /// {} - ReadGlobal(0) - {C}
+    ReadGlobal(usize),
+    /// Sets the given constant, and pops
+    /// the topmost element.
+    ///
+    /// {A} - AssignGlobal(0) - {}
+    AssignGlobal(usize),
+
     /// A helper instruction for the type checker.
     /// *Makes sure* that the top value on the stack
     /// is of the given type, and is meant to signal

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -943,10 +943,11 @@ impl Block {
                 },
                 i.red(),
                 s,
-                if let (Op::Constant(c), Some(constants)) = (s, constants) {
-                    format!("    => {:?}", &constants[*c])
-                } else {
-                    "".to_string()
+                match (s, constants) {
+                    (Op::Constant(c), Some(constants))
+                    | (Op::Link(c), Some(constants))
+                      => format!("    => {:?}", &constants[*c]),
+                    _ => "".to_string()
                 }
             );
         }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -213,8 +213,11 @@ impl VM {
             }
 
             Op::ReadGlobal(slot) => {
-                let ty = self.global_types[slot].clone();
-                self.push(ty);
+                if let Some(ty) = self.global_types.get(slot).cloned() {
+                    self.push(ty);
+                } else {
+                    self.push(Type::Unknown);
+                }
             }
 
             Op::AssignGlobal(slot) => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -387,6 +387,15 @@ impl VM {
                 }
             }
 
+            Op::ReadGlobal(slot) => {
+                let global = self.stack[slot].clone();
+                self.push(global);
+            }
+
+            Op::AssignGlobal(slot) => {
+                self.stack[slot] = self.pop();
+            }
+
             Op::Contains => {
                 let (element, container) = self.poppop();
                 match (container, element) {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -388,8 +388,12 @@ impl VM {
             }
 
             Op::ReadGlobal(slot) => {
-                let global = self.stack[slot].clone();
-                self.push(global);
+                if self.stack.len() > slot {
+                    let global = self.stack[slot].clone();
+                    self.push(global);
+                } else {
+                    error!(self, RuntimeError::InvalidProgram);
+                }
             }
 
             Op::AssignGlobal(slot) => {


### PR DESCRIPTION
Globals are now a special case - it was easier than changeing how the scoping was done.

The compiler no longer recognizes circular dependencies for globals, they are caught very
poorly during runtime. We should be able to find them in the compiler stage - at the latest
typechecker stage - but I was lazy and did it in the runtime.

It fells a bit hacky, and might need some tweaking so input is appriciated.
