### PR TITLE
Time runtime and do some statistical analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,7 @@ checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 [[package]]
 name = "lingon"
 version = "0.1.0"
+source = "git+https://github.com/sornas/lingon.git?branch=main#b9e65f995846b324ca9e130aa4e6c35f47ee2288"
 dependencies = [
  "cgmath",
  "lazy_static",
@@ -422,6 +423,7 @@ dependencies = [
 [[package]]
 name = "lingon_macro"
 version = "0.1.0"
+source = "git+https://github.com/sornas/lingon.git?branch=main#b9e65f995846b324ca9e130aa4e6c35f47ee2288"
 dependencies = [
  "lazy_static",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "sylt"
 version = "0.1.0"
 authors = ["Edvard Thörnros <edvard.thornros@gmail.com>", "Gustav Sörnäs <gustav@sornas.net>"]
 edition = "2018"
+default-run = "sylt"
 
 [lib]
 name = "sylt"

--- a/progs/bench/fib.sy
+++ b/progs/bench/fib.sy
@@ -8,6 +8,7 @@ fib :: fn a:int -> int {
 }
 // 23 is around where things start getting slow.
 start :: fn {
+    // fib(22) <=> 17711
     fib(23) <=> 28657
 }
 

--- a/src/bin/time.rs
+++ b/src/bin/time.rs
@@ -1,14 +1,11 @@
 use gumdrop::Options;
-use std::{io::{Write, stdout}, path::PathBuf};
+use std::path::PathBuf;
 use std::time::Instant;
 
 #[derive(Default, Debug, Options)]
 pub struct Args {
     #[options(free, required, help = "The file to run")]
     pub run_file: PathBuf,
-
-    #[options(free, help = "The file to write the runtimes to (omit or '-' for stdout)")]
-    pub stat_file: Option<PathBuf>,
 
     #[options(short = "r", long = "runs", help = "If set, how many times the program should be run at most")]
     pub max_runs: Option<u32>,
@@ -83,18 +80,8 @@ fn main() -> std::io::Result<()> {
         runtimes.push(runtime.as_micros());
     }
 
-    eprintln!("Saving to file");
-    match args.stat_file {
-        Some(file) => write_stats(&mut std::fs::File::create(file).unwrap(), &runtimes)?,
-        None => write_stats(&mut stdout(), &runtimes)?,
-    }
-
-    Ok(())
-}
-
-fn write_stats<W: Write>(to: &mut W, stats: &[u128]) -> std::io::Result<()> {
-    for stat in stats {
-        writeln!(to, "{}", stat)?;
+    for runtime in runtimes {
+        println!("{}", runtime);
     }
     Ok(())
 }

--- a/src/bin/time.rs
+++ b/src/bin/time.rs
@@ -8,7 +8,7 @@ pub struct Args {
     pub run_file: PathBuf,
 
     #[options(short = "r", long = "runs", help = "If set, how many times the program should be run at most")]
-    pub max_runs: Option<u32>,
+    pub max_runs: Option<usize>,
 
     #[options(short = "t", long = "time", help = "If set, stop running when this amount of seconds have passed")]
     pub max_time: Option<u64>,
@@ -18,7 +18,7 @@ pub struct Args {
 }
 
 fn main() -> std::io::Result<()> {
-    let args = Args::parse_args_or_exit(gumdrop::ParsingStyle::AllOptions);
+    let args = Args::parse_args_default_or_exit();
     if args.help {
         eprintln!("{}", Args::usage());
         return Ok(());
@@ -60,10 +60,9 @@ fn main() -> std::io::Result<()> {
 
     eprintln!("Starting runs");
     let outer_start = Instant::now();
-    let mut runs = 0;
     loop {
         if let Some(max_runs) = args.max_runs {
-            if runs >= max_runs {
+            if runtimes.len() >= max_runs {
                 break;
             }
         }
@@ -72,7 +71,6 @@ fn main() -> std::io::Result<()> {
                 break;
             }
         }
-        runs += 1;
 
         let start = Instant::now();
         let _ = sylt::run(&prog, &sylt_args).unwrap();

--- a/src/bin/time.rs
+++ b/src/bin/time.rs
@@ -1,0 +1,100 @@
+use gumdrop::Options;
+use std::{io::{Write, stdout}, path::PathBuf};
+use std::time::Instant;
+
+#[derive(Default, Debug, Options)]
+pub struct Args {
+    #[options(free, required, help = "The file to run")]
+    pub run_file: PathBuf,
+
+    #[options(free, help = "The file to write the runtimes to (omit or '-' for stdout)")]
+    pub stat_file: Option<PathBuf>,
+
+    #[options(short = "r", long = "runs", help = "If set, how many times the program should be run at most")]
+    pub max_runs: Option<u32>,
+
+    #[options(short = "t", long = "time", help = "If set, stop running when this amount of seconds have passed")]
+    pub max_time: Option<u64>,
+
+    #[options(help = "Print this help")]
+    pub help: bool,
+}
+
+fn main() -> std::io::Result<()> {
+    let args = Args::parse_args_or_exit(gumdrop::ParsingStyle::AllOptions);
+    if args.help {
+        eprintln!("{}", Args::usage());
+        return Ok(());
+    }
+
+    let sylt_args = sylt::Args {
+        file: Some(args.run_file),
+        is_binary: false,
+        compile_target: None,
+        verbosity: 0,
+        help: false,
+    };
+
+    eprintln!("Compiling");
+    let functions = sylt::lib_bindings();
+    let prog = match sylt::compile(&sylt_args, functions) {
+        Ok(prog) => prog,
+        Err(errs) => {
+            for err in errs {
+                eprintln!("{}", err);
+            }
+            return Ok(());
+        }
+    };
+
+    eprintln!("Running once");
+    // Run once and report any errors
+    match sylt::run(&prog, &sylt_args) {
+        Ok(_) => (),
+        Err(errs) => {
+            eprintln!("Runtime error(s):");
+            for err in errs {
+                eprintln!("{}", err);
+            }
+            return Ok(());
+        }
+    }
+    let mut runtimes = Vec::new();
+
+    eprintln!("Starting runs");
+    let outer_start = Instant::now();
+    let mut runs = 0;
+    loop {
+        if let Some(max_runs) = args.max_runs {
+            if runs >= max_runs {
+                break;
+            }
+        }
+        if let Some(max_time) = args.max_time {
+            if (Instant::now() - outer_start).as_secs() >= max_time {
+                break;
+            }
+        }
+        runs += 1;
+
+        let start = Instant::now();
+        let _ = sylt::run(&prog, &sylt_args).unwrap();
+        let runtime = Instant::now() - start;
+        runtimes.push(runtime.as_micros());
+    }
+
+    eprintln!("Saving to file");
+    match args.stat_file {
+        Some(file) => write_stats(&mut std::fs::File::create(file).unwrap(), &runtimes)?,
+        None => write_stats(&mut stdout(), &runtimes)?,
+    }
+
+    Ok(())
+}
+
+fn write_stats<W: Write>(to: &mut W, stats: &[u128]) -> std::io::Result<()> {
+    for stat in stats {
+        writeln!(to, "{}", stat)?;
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub fn run(prog: &Prog, args: &Args) -> Result<(), Vec<Error>> {
     }
 }
 
-fn compile(args: &Args, functions: Vec<(String, RustFunction)>) -> Result<Prog, Vec<Error>> {
+pub fn compile(args: &Args, functions: Vec<(String, RustFunction)>) -> Result<Prog, Vec<Error>> {
     let path = match &args.file {
         Some(file) => file,
         None => {

--- a/time_analysis.py
+++ b/time_analysis.py
@@ -13,7 +13,9 @@ if len(sys.argv) < 3:
 values = [[int(n) for n in open(file, "r").readlines()]
           for file in sys.argv[1:3]]
 
+# Get the mean/variance
 stats = list(map(scipy_stats.describe, values))
+# Calculate both with and without the assumption of equal variance
 p_eq_var = scipy_stats.ttest_ind(*values, equal_var=True).pvalue
 p_uneq_var = scipy_stats.ttest_ind(*values, equal_var=False).pvalue
 
@@ -25,6 +27,8 @@ print("Standard deviation")
 for stat in stats:
     print(f"{stat.variance**(1/2):.3f}")
 print()
+# Normal p-values are p<0.05 or even p<0.01 for statistical significance.
+# Perhaps try a baseline where you compare the programs with themselves.
 print("P values (small values -> reject equal mean hypothesis):")
 print("Equal variance   Unequal variance")
 print(f"{p_eq_var:.3f}            {p_uneq_var:.3f}")

--- a/time_analysis.py
+++ b/time_analysis.py
@@ -1,0 +1,26 @@
+import sys
+
+try:
+    from scipy import stats as scipy_stats
+except ModuleNotFoundError:
+    print("Need scipy for statistical analysis", file=sys.stderr)
+    sys.exit(1)
+
+if len(sys.argv) < 3:
+    print("Need two filenames to compare", file=sys.stderr)
+    sys.exit(1)
+
+values = [[int(n) for n in open(file, "r").readlines()]
+          for file in sys.argv[1:3]]
+
+stats = list(map(scipy_stats.describe, values))
+p_eq_var = scipy_stats.ttest_ind(*values, equal_var=True).pvalue
+p_uneq_var = scipy_stats.ttest_ind(*values, equal_var=False).pvalue
+
+print("Mean   Standard deviation")
+for stat in stats:
+    print(f"{stat.mean:.3f}  {stat.variance:.3f}")
+print()
+print("P values (small values -> reject equal mean hypothesis):")
+print("Equal variance   Unequal variance")
+print(f"{p_eq_var:.3f}            {p_uneq_var:.3f}")

--- a/time_analysis.py
+++ b/time_analysis.py
@@ -35,19 +35,15 @@ except ModuleNotFoundError:
     sys.exit(1)
 
 # Get the mean/variance
-stats = list(map(scipy_stats.describe, values))
+stats = zip(sys.argv[1:3], list(map(scipy_stats.describe, values)))
 # Calculate both p-values with and without the assumption of equal variance
 p_eq_var = scipy_stats.ttest_ind(*values, equal_var=True).pvalue
 p_uneq_var = scipy_stats.ttest_ind(*values, equal_var=False).pvalue
 
-print("Mean")
-for stat in stats:
-    print(f"{stat.mean:.3f}")
+for (f, stat) in stats:
+    print(f"{f:>10}: {stat.mean:15.3f}ms ± {stat.variance**(1/2):.3f}ms")
 print()
-print("Standard deviation")
-for stat in stats:
-    print(f"{stat.variance**(1/2):.3f}")
-print()
+
 # Normal p-values are p<0.05 or even p<0.01 for statistical significance.
 # Perhaps try a baseline where you compare the programs with themselves.
 print("P values (small values -> reject equal mean hypothesis):")

--- a/time_analysis.py
+++ b/time_analysis.py
@@ -17,9 +17,13 @@ stats = list(map(scipy_stats.describe, values))
 p_eq_var = scipy_stats.ttest_ind(*values, equal_var=True).pvalue
 p_uneq_var = scipy_stats.ttest_ind(*values, equal_var=False).pvalue
 
-print("Mean   Standard deviation")
+print("Mean")
 for stat in stats:
-    print(f"{stat.mean:.3f}  {stat.variance:.3f}")
+    print(f"{stat.mean:.3f}")
+print()
+print("Standard deviation")
+for stat in stats:
+    print(f"{stat.variance**(1/2):.3f}")
 print()
 print("P values (small values -> reject equal mean hypothesis):")
 print("Equal variance   Unequal variance")

--- a/time_analysis.py
+++ b/time_analysis.py
@@ -1,21 +1,42 @@
 import sys
 
+if len(sys.argv) == 1:
+    print(f"usage: {sys.argv[0]} [<file1> <file2> | '-']")
+    print()
+    print("Description:")
+    print(" Compare the two sets of numbers given in <file1> and <file2>.")
+    print(" If '-' is specified, input is read from stdin as ")
+    print(" newline-delimited numbers with a '$' separating the two sets.")
+    print(" The two sets should contain the same amount of numbers.")
+    print()
+    print("Output:")
+    print(" Mean, standard deviation and the result from two hypothesis tests")
+    print(" are printed to stdout. The null hypotheses of the two tests are")
+    print(" that the two means are the same. The first test assumes equal")
+    print(" variance, while the second does not.")
+    sys.exit(0)
+
+if sys.argv[1] == "-":
+    # read two files delimited by '$' from stdin
+    values = "".join(sys.stdin.readlines()).split("$\n")
+    values = [[int(n) for n in lst.strip().split("\n")] for lst in values]
+elif len(sys.argv) == 2:
+    print("Either two files or '-' should be specified", file=sys.stderr)
+    sys.exit(1)
+else:
+    # read the first two files passes as arguments
+    values = [[int(n) for n in open(file, "r").readlines()]
+              for file in sys.argv[1:3]]
+
 try:
     from scipy import stats as scipy_stats
 except ModuleNotFoundError:
     print("Need scipy for statistical analysis", file=sys.stderr)
     sys.exit(1)
 
-if len(sys.argv) < 3:
-    print("Need two filenames to compare", file=sys.stderr)
-    sys.exit(1)
-
-values = [[int(n) for n in open(file, "r").readlines()]
-          for file in sys.argv[1:3]]
-
 # Get the mean/variance
 stats = list(map(scipy_stats.describe, values))
-# Calculate both with and without the assumption of equal variance
+# Calculate both p-values with and without the assumption of equal variance
 p_eq_var = scipy_stats.ttest_ind(*values, equal_var=True).pvalue
 p_uneq_var = scipy_stats.ttest_ind(*values, equal_var=False).pvalue
 


### PR DESCRIPTION
It's a bit rough around the edges but the logic is all there.

Motivation: Timing the entire binary also counts compilation and file IO, which isn't really what we want. With this we test only the runtime of the program and do our own statisticial analysis (kinda) using scipy.

```sh
~/dev/sylt $ cargo run --release --bin time -- -r 100 progs/bench/fib_iter.sy > stats1
    Finished release [optimized] target(s) in 0.03s
     Running `target/release/time -r 100 progs/bench/fib_iter.sy`
Compiling
Running once
Starting runs
~/dev/sylt $ cargo run --release --bin time -- -r 100 progs/bench/fib_iter.sy > stats2
    Finished release [optimized] target(s) in 0.03s
     Running `target/release/time -r 100 progs/bench/fib_iter.sy`
Compiling
Running once
Starting runs
~/dev/sylt $ wc -l stats1 stats2
 100 stats1
 100 stats2
 200 total
~/dev/sylt $ python time_analysis.py stats1 stats2
Mean
29749.880
30175.730

Standard deviation
1181.843
1629.033

P values (small values -> reject equal mean hypothesis):
Equal variance   Unequal variance
0.036            0.036
~/dev/sylt $ 
```

We could look into https://github.com/PyO3/pyo3 and do the analysis in Rust as well.