### PR TITLE
syntax trees building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.coverage
 target
 tags

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,7 @@
+RUSTFLAGS=-Zinstrument-coverage LLVM_PROFILE_FILE=./.coverage/coverage-%p-%m.profraw cargo +nightly test
+
+grcov . --binary-path ./target/debug/ -s . -t html --ignore-not-existing --ignore "*cargo*" -o ./.coverage/
+xdg-open ./.coverage/src/index.html
+
+#grcov . --binary-path ./target/debug/ -s . -t lcov --ignore-not-existing --ignore "*cargo*" -o ./.coverage/coverage.lcov
+#lcov --summary ./.coverage/coverage.lcov

--- a/src/bin/time.rs
+++ b/src/bin/time.rs
@@ -30,6 +30,7 @@ fn main() -> std::io::Result<()> {
         compile_target: None,
         verbosity: 0,
         help: false,
+        ..Default::default()
     };
 
     eprintln!("Compiling");

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -121,6 +121,7 @@ pub enum Prec {
     Term,
     Factor,
     Index,
+    Arrow,
 }
 
 #[derive(Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub trait Next {
     fn next(&self) -> Self;
 }
 
-pub fn construct_tree(args: &Args) -> Result<syntree::Prog, Vec<Error>> {
+pub fn construct_tree(args: &Args) -> Result<syntree::Module, Vec<Error>> {
     let path = match &args.file {
         Some(file) => file,
         None => {
@@ -54,7 +54,7 @@ pub fn construct_tree(args: &Args) -> Result<syntree::Prog, Vec<Error>> {
     let tokens = tokenizer::file_to_tokens(path).map_err(|_| {
         vec![Error::FileNotFound(path.to_path_buf())]
     })?;
-    syntree::construct(tokens)
+    syntree::construct(tokens.as_slice())
 }
 
 /// Compiles, links and runs the given file. The supplied functions are callable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,16 @@ pub trait Next {
 }
 
 pub fn construct_tree(args: &Args) -> Result<syntree::Prog, Vec<Error>> {
-    Err(Vec::new())
+    let path = match &args.file {
+        Some(file) => file,
+        None => {
+            return Err(vec![Error::NoFileGiven]);
+        }
+    };
+    let tokens = tokenizer::file_to_tokens(path).map_err(|_| {
+        vec![Error::FileNotFound(path.to_path_buf())]
+    })?;
+    syntree::construct(tokens)
 }
 
 /// Compiles, links and runs the given file. The supplied functions are callable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,10 @@ pub trait Next {
     fn next(&self) -> Self;
 }
 
+pub fn construct_tree(args: &Args) -> Result<syntree::Prog, Vec<Error>> {
+    Err(Vec::new())
+}
+
 /// Compiles, links and runs the given file. The supplied functions are callable
 /// external functions.
 pub fn run_file(args: &Args, functions: Vec<(String, RustFunction)>) -> Result<(), Vec<Error>> {
@@ -87,6 +91,9 @@ pub struct Args {
 
     #[options(short = "c", long = "compile", help = "Compile a sylt binary")]
     pub compile_target: Option<PathBuf>,
+
+    #[options(short = "t", long = "tree", help = "Use the syntax tree backend (WIP)")]
+    pub tree_mode: bool,
 
     #[options(short = "v", no_long, count, help = "Increase verbosity, up to max 2")]
     pub verbosity: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,17 +44,14 @@ pub trait Next {
     fn next(&self) -> Self;
 }
 
-pub fn construct_tree(args: &Args) -> Result<syntree::Module, Vec<Error>> {
+pub fn construct_tree(args: &Args) -> Result<syntree::Prog, Vec<Error>> {
     let path = match &args.file {
         Some(file) => file,
         None => {
             return Err(vec![Error::NoFileGiven]);
         }
     };
-    let tokens = tokenizer::file_to_tokens(path).map_err(|_| {
-        vec![Error::FileNotFound(path.to_path_buf())]
-    })?;
-    syntree::construct(&path, tokens.as_slice())
+    syntree::tree(&path)
 }
 
 /// Compiles, links and runs the given file. The supplied functions are callable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub fn construct_tree(args: &Args) -> Result<syntree::Module, Vec<Error>> {
     let tokens = tokenizer::file_to_tokens(path).map_err(|_| {
         vec![Error::FileNotFound(path.to_path_buf())]
     })?;
-    syntree::construct(tokens.as_slice())
+    syntree::construct(&path, tokens.as_slice())
 }
 
 /// Compiles, links and runs the given file. The supplied functions are callable

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), String> {
                 Err(format!("{} errors occured.", errs.len()))
             }
             Ok(tree) => {
-                println!("{:?}", tree);
+                println!("{:#?}", tree);
                 Ok(())
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,13 +12,28 @@ fn main() -> Result<(), String> {
     }
 
     let functions = lib_bindings();
-    let res = sylt::run_file(&args, functions);
-
-    if let Err(errs) = res {
-        for err in errs.iter() {
-            println!("{}", err);
+    if args.tree_mode {
+        match sylt::construct_tree(&args) {
+            Err(errs) => {
+                for err in errs.iter() {
+                    println!("{}", err);
+                }
+                Err(format!("{} errors occured.", errs.len()))
+            }
+            Ok(tree) => {
+                println!("{:?}", tree);
+                Ok(())
+            }
         }
-        return Err(format!("{} errors occured.", errs.len()));
+    } else {
+        let res = sylt::run_file(&args, functions);
+
+        if let Err(errs) = res {
+            for err in errs.iter() {
+                println!("{}", err);
+            }
+            return Err(format!("{} errors occured.", errs.len()));
+        }
+        Ok(())
     }
-    Ok(())
 }

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -168,7 +168,7 @@ pub enum ExpressionKind {
     // Simple
     Float(f64),
     Int(i64),
-    String(String),
+    Str(String),
     Bool(bool),
     Nil,
 }
@@ -312,7 +312,7 @@ fn expression<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
                 T::Int(i) => Int(i),
                 T::Bool(b) => Bool(b),
                 T::Nil => Nil,
-                T::String(s) => String(s),
+                T::String(s) => Str(s),
                 t => {
                     raise_syntax_error!(ctx, "Cannot parse value, '{:?}' is not a valid value", t);
                 }
@@ -486,8 +486,8 @@ pub fn construct(tokens: &Tokens) -> Result<Module, Vec<Error>> {
 mod test {
     use crate::tokenizer::string_to_tokens;
     use super::*;
-    use StatementKind::*;
     use ExpressionKind::*;
+    use AssignableKind::*;
 
     macro_rules! test_expression {
         ($name:ident: $str:expr => $ans:pat) => {
@@ -509,4 +509,19 @@ mod test {
     }
 
     test_expression!(simple_expr: "0" => Expression { kind: Int(0), .. });
+    test_expression!(simple_add: "0 + 1.0" => Expression { kind: Add(_, _), ..  });
+    test_expression!(simple_mul: "\"abc\" * \"abc\"" => Expression { kind: Mul(_, _), ..  });
+    test_expression!(simple_ident: "a" => Expression {
+        kind: Get(Assignable { kind: Read(_), .. }),
+        ..
+    });
+    test_expression!(simple_access: "a.b" => Expression {
+        kind: Get(Assignable { kind: Access(_, _), .. }), ..
+    });
+    test_expression!(simple_index_ident: "a[a]" => Expression {
+        kind: Get(Assignable { kind: Index(_, _), .. }), ..
+    });
+    test_expression!(simple_index_expr: "a[1 + 2 + 3]" => Expression {
+        kind: Get(Assignable { kind: Index(_, _), .. }), ..
+    });
 }

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -1020,13 +1020,26 @@ mod test {
 
         test!(parse_type, type_dict_one: "{int : int}" => Dict(_, _));
         test!(parse_type, type_dict_complex: "{int | float? : int | int | int?}" => Dict(_, _));
+
+        // TODO(ed): Require block or allow all statements?
+        test!(expression, simple: "fn -> {}" => _);
+        test!(expression, argument: "fn a: int -> int ret a + 1" => _);
     }
 
-    mod function {
+    mod statement {
         use super::*;
 
         // NOTE(ed): Expressions are valid statements! :D
-        test!(expression, simple: "fn -> {}" => _);
-        test!(expression, argument: "fn a: int -> int ret a + 1" => _);
+        test!(statement, statement_expression: "1 + 1" => _);
+        test!(statement, statement_print: "print 1" => _);
+        test!(statement, statement_mut_declaration: "a := 1 + 1" => _);
+        test!(statement, statement_const_declaration: "a :: 1 + 1" => _);
+        test!(statement, statement_mut_type_declaration: "a :int= 1 + 1" => _);
+        test!(statement, statement_const_type_declaration: "a :int: 1 + 1" => _);
+        test!(statement, statement_if: "if 1 { print a }" => _);
+        test!(statement, statement_if_else: "if 1 { print a } else { print b }" => _);
+        test!(statement, statement_loop: "loop 1 { print a }" => _);
+        test!(statement, statement_ret: "ret 1 + 1" => _);
+        test!(statement, statement_unreach: "<!>" => _);
     }
 }

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -702,7 +702,7 @@ mod test {
                 );
                 let (ctx, result) = result.unwrap();
                 assert!(matches!(result.kind, $ans), "\nExpected: {}, but got: {:?}", stringify!($ans), result);
-                assert_eq!(ctx.curr, ctx.tokens.len(), "Ate past the end of the buffer for:\n{}", $str);
+                assert_eq!(ctx.curr, ctx.tokens.len(), "Parsed too few or too many tokens:\n{}", $str);
             }
         }
     }
@@ -752,7 +752,7 @@ mod test {
                 );
                 let (ctx, result) = result.unwrap();
                 assert!(matches!(result.kind, $ans), "\nExpected: {}, but got: {:?}", stringify!($ans), result);
-                assert_eq!(ctx.curr, ctx.tokens.len(), "Ate past the end of the buffer for:\n{}", $str);
+                assert_eq!(ctx.curr, ctx.tokens.len(), "Parsed too few or too many tokens:\n{}", $str);
             }
         }
     }

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -683,18 +683,18 @@ mod test {
 
     // TODO(ed): It's really hard to write good tests, Rust refuses to deref the boxes
     // automatically.
-    test_expression!(simple_expr: "0" => Int(0));
-    test_expression!(simple_add: "0 + 1.0" => Add(_, _));
-    test_expression!(simple_mul: "\"abc\" * \"abc\"" => Mul(_, _));
-    test_expression!(simple_ident: "a" => Get(Assignable { kind: Read(_), .. }));
-    test_expression!(simple_access: "a.b" => Get(Assignable { kind: Access(_, _), .. }));
-    test_expression!(simple_index_ident: "a[a]" => Get(Assignable { kind: Index(_, _), .. }));
-    test_expression!(simple_index_expr: "a[1 + 2 + 3]" => Get(Assignable { kind: Index(_, _), .. }));
-    test_expression!(simple_grouping: "(0 * 0) + 1" => Add(_, _));
-    test_expression!(simple_tuple: "(0, 0)" => Tuple(_));
-    test_expression!(simple_list: "[0, 0]" => List(_));
-    test_expression!(simple_set: "{1, 1}" => Set(_));
-    test_expression!(simple_dict: "{1: 1}" => Dict(_));
+    test_expression!(value: "0" => Int(0));
+    test_expression!(add: "0 + 1.0" => Add(_, _));
+    test_expression!(mul: "\"abc\" * \"abc\"" => Mul(_, _));
+    test_expression!(ident: "a" => Get(Assignable { kind: Read(_), .. }));
+    test_expression!(access: "a.b" => Get(Assignable { kind: Access(_, _), .. }));
+    test_expression!(index_ident: "a[a]" => Get(Assignable { kind: Index(_, _), .. }));
+    test_expression!(index_expr: "a[1 + 2 + 3]" => Get(Assignable { kind: Index(_, _), .. }));
+    test_expression!(grouping: "(0 * 0) + 1" => Add(_, _));
+    test_expression!(tuple: "(0, 0)" => Tuple(_));
+    test_expression!(list: "[0, 0]" => List(_));
+    test_expression!(set: "{1, 1}" => Set(_));
+    test_expression!(dict: "{1: 1}" => Dict(_));
     test_expression!(zero_set: "{}" => Set(_));
     test_expression!(zero_dict: "{:}" => Dict(_));
 

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -273,7 +273,7 @@ macro_rules! raise_syntax_error {
 }
 
 macro_rules! expect {
-    ($ctx:expr, $( $token:pat )|+ , $( $msg:expr ),+ ) => {
+    ($ctx:expr, $( $token:pat )|+ , $( $msg:expr ),+) => {
         {
             if !matches!($ctx.token(), $( $token )|* ) {
                 raise_syntax_error!($ctx, $( $msg ),*);

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -1018,9 +1018,8 @@ fn outer_statement<'t>(ctx: Context<'t>) -> ParseResult<Statement> {
     statement(ctx)
 }
 
-pub fn construct(tokens: &Tokens) -> Result<Module, Vec<Error>> {
-    let path = PathBuf::from("hello.sy");
-    let mut ctx = Context::new(tokens, &path);
+pub fn construct(path: &Path, tokens: &Tokens) -> Result<Module, Vec<Error>> {
+    let mut ctx = Context::new(tokens, path);
     let mut errors = Vec::new();
     let mut statements = Vec::new();
     while !matches!(ctx.token(), T::EOF) {
@@ -1035,8 +1034,13 @@ pub fn construct(tokens: &Tokens) -> Result<Module, Vec<Error>> {
                 }
                 ctx
             }
-            Err((ctx, mut errs)) => {
+            Err((mut ctx, mut errs)) => {
                 errors.append(&mut errs);
+
+                // "Error recovery"
+                while !matches!(ctx.token(), T::EOF | T::Newline) {
+                    ctx = ctx.skip(1);
+                }
                 ctx
             }
         }

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -288,7 +288,7 @@ macro_rules! expect {
 }
 
 macro_rules! skip_if {
-    ($ctx:expr, $( $token:pat )|+) => {
+    ($ctx:expr, $( $token:pat )|+ ) => {
         {
             if matches!($ctx.token(), $( $token )|* ) {
                 $ctx.skip(1)

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
+use std::path::{PathBuf, Path};
 use std::collections::HashMap;
 use crate::error::Error;
-use crate::tokenizer::TokenStream;
+use crate::tokenizer::{TokenStream, Token};
 use super::Type as runtimeType;
 
 #[derive(Debug, Copy, Clone)]
@@ -189,6 +189,115 @@ pub struct Type {
     kind: TypeKind,
 }
 
-pub fn construct(tokens: TokenStream) -> Result<Prog, Vec<Error>> {
-    Err(Vec::new())
+type Tokens = [(Token, usize)];
+
+#[derive(Debug, Copy, Clone)]
+struct Context<'a> {
+    pub tokens: &'a Tokens,
+    pub curr: usize,
+    pub file: &'a Path,
+}
+
+impl<'a> Context<'a> {
+
+    fn new(tokens: &'a [(Token, usize)], file: &'a Path) -> Self {
+        Self { tokens, curr: 0, file, }
+    }
+
+    fn span(&self) -> Span {
+        Span { line: self.peek().1 }
+    }
+
+    fn line(&self) -> usize {
+        self.span().line
+    }
+
+    fn skip(&self, n: usize) -> Self {
+        let mut new = self.clone();
+        new.curr += n;
+        new
+    }
+
+    fn peek(&self) -> &(Token, usize) {
+        &self.tokens.get(self.curr).unwrap_or(&(Token::EOF, 0))
+    }
+
+    fn token(&self) -> &Token {
+        &self.peek().0
+    }
+
+    fn eat(&self) -> (&Token, Span, Context) {
+        (self.token(), self.span(), self.skip(1))
+    }
+}
+
+macro_rules! syntax_error {
+    ($ctx:expr, $( $msg:expr ),* ) => {
+        {
+            let msg = format!($( $msg ),*).into();
+            Error::SyntaxError {
+                file: $ctx.file.to_path_buf(),
+                line: $ctx.line(),
+                token: $ctx.token().clone(),
+                message: Some(msg),
+            }
+        }
+    };
+}
+
+macro_rules! raise_syntax_error {
+    ($ctx:expr, $( $msg:expr ),* ) => {
+        return Err(($ctx.skip(1), vec![syntax_error!($ctx, $( $msg ),*)]))
+    };
+}
+
+fn expression<'t>(ctx: Context<'t>) -> Result<(Context<'t>, Expression), (Context<'t>, Vec<Error>)> {
+    use Token as T;
+    use ExpressionKind::*;
+    let span = ctx.span();
+    Ok(match ctx.token() {
+        T::Float(v) => (ctx.skip(1), Expression { span, kind: Float(*v), }),
+        T::Int(v) => (ctx.skip(1), Expression { span, kind: Int(*v), }),
+        _ => {
+            raise_syntax_error!(ctx.skip(1), "Failed to parse expression");
+        }
+    })
+}
+
+fn outer_statement<'t>(ctx: Context<'t>) -> Result<(Context<'t>, Statement), (Context<'t>, Vec<Error>)> {
+    let span = ctx.span();
+    let (ctx, value) = expression(ctx)?;
+
+    use StatementKind::*;
+    Ok((ctx, Statement { span, kind: StatementExpression { value } }))
+}
+
+pub fn construct(tokens: &Tokens) -> Result<Module, Vec<Error>> {
+    let path = PathBuf::from("hello.sy");
+    let mut ctx = Context::new(tokens, &path);
+    let mut errors = Vec::new();
+    let mut statements = Vec::new();
+    while !matches!(ctx.token(), Token::EOF) {
+        if matches!(ctx.peek().0, Token::Newline) {
+            ctx = ctx.skip(1);
+            continue;
+        }
+        println!("A {:?}", ctx.peek());
+        ctx = match outer_statement(ctx) {
+            Ok((_ctx, statement)) => {
+                statements.push(statement);
+                _ctx
+            }
+            Err((_ctx, mut errs)) => {
+                errors.append(&mut errs);
+                _ctx
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(Module { span: Span { line: 0 }, statements })
+    } else {
+        Err(errors)
+    }
 }

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -1370,13 +1370,14 @@ mod test {
         test!(expression, bool_neg: "!a" => _);
 
         test!(expression, cmp_eq: "a == b" => _);
+        test!(expression, cmp_neq: "a != b" => _);
         test!(expression, cmp_leq: "a <= b" => _);
         test!(expression, cmp_geq: "a >= b" => _);
         test!(expression, cmp_gt: "a > b" => _);
         test!(expression, cmp_lt: "a < b" => _);
         test!(expression, neg: "-a" => _);
 
-        test!(expression, expr: "-a + b < 3 + true && false" => _);
+        test!(expression, expr: "-a + b < 3 * true && false / 2" => _);
 
         test!(expression, void_simple: "fn {}" => _);
         test!(expression, void_argument: "fn a: int { ret a + 1 }" => _);

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -1187,6 +1187,8 @@ mod test {
         test!(statement, statement_const_declaration: "a :: 1 + 1" => _);
         test!(statement, statement_mut_type_declaration: "a :int= 1 + 1" => _);
         test!(statement, statement_const_type_declaration: "a :int: 1 + 1" => _);
+        test!(statement, statement_force_mut_type_declaration: "a :!int= 1 + 1" => _);
+        test!(statement, statement_force_const_type_declaration: "a :!int: 1 + 1" => _);
         test!(statement, statement_if: "if 1 { print a }" => _);
         test!(statement, statement_if_else: "if 1 { print a } else { print b }" => _);
         test!(statement, statement_loop: "loop 1 { print a }" => _);

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -875,7 +875,7 @@ mod expression {
 
             T::Minus | T::Plus => Prec::Term,
 
-            T::EqualEqual 
+            T::EqualEqual
             | T::Greater
             | T::GreaterEqual
             | T::Less
@@ -1424,6 +1424,10 @@ mod test {
         test!(statement, statement_blob_comma_newline: "A :: blob { a: int,\n b: int }" => _);
         test!(statement, statement_assign: "a = 1" => _);
         test!(statement, statement_assign_index: "a.b = 1 + 2" => _);
+        test!(statement, statement_add_assign: "a += 2" => _);
+        test!(statement, statement_sub_assign: "a -= 2" => _);
+        test!(statement, statement_mul_assign: "a *= 2" => _);
+        test!(statement, statement_div_assign: "a /= 2" => _);
         test!(statement, statement_assign_call: "a().b() += 2" => _);
         test!(statement, statement_assign_call_index: "a.c().c.b /= 4" => _);
         test!(statement, statement_idek: "a!.c!.c.b()().c = 0" => _);

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -902,5 +902,14 @@ mod test {
 
         test!(parse_type, type_tuple_one: "(int)" => Tuple(_));
         test!(parse_type, type_tuple_complex: "(int | float?, str, str,)" => Tuple(_));
+
+        test!(parse_type, type_list_one: "[int]" => List(_));
+        test!(parse_type, type_list_complex: "[int | float?]" => List(_));
+
+        test!(parse_type, type_set_one: "{int}" => Set(_));
+        test!(parse_type, type_set_complex: "{int | float?}" => Set(_));
+
+        test!(parse_type, type_dict_one: "{int : int}" => Dict(_, _));
+        test!(parse_type, type_dict_complex: "{int | float? : int | int | int?}" => Dict(_, _));
     }
 }

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -419,7 +419,11 @@ fn expression<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
 
             loop {
                 match (ctx.token(), banger) {
-                    (T::EOF, _) | (T::RightParen, false) | (T::Dot, true) | (T::Newline, true)
+                    (T::EOF, _)
+                    | (T::RightParen, false)
+                    | (T::Dot, true)
+                    | (T::Newline, true)
+                    | (T::Arrow, true)
                         => { break; }
 
                     _ => {

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -273,7 +273,7 @@ macro_rules! raise_syntax_error {
 }
 
 macro_rules! expect {
-    ($ctx:expr, $( $token:pat )|+ , $( $msg:expr ),+) => {
+    ($ctx:expr, $( $token:pat )|+ , $( $msg:expr ),+ ) => {
         {
             if !matches!($ctx.token(), $( $token )|* ) {
                 raise_syntax_error!($ctx, $( $msg ),*);

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -141,6 +141,8 @@ pub enum ExpressionKind {
     Lteq(Box<Expression>, Box<Expression>),
     AssertEq(Box<Expression>, Box<Expression>),
 
+    In(Box<Expression>, Box<Expression>),
+
     And(Box<Expression>, Box<Expression>),
     Or(Box<Expression>, Box<Expression>),
     Not(Box<Expression>),
@@ -725,6 +727,8 @@ fn expression<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
                 T::And => Prec::BoolAnd,
                 T::Or => Prec::BoolOr,
 
+                T::In => Prec::Index,
+
                 T::AssertEqual => Prec::Assert,
 
                 T::Arrow => Prec::Arrow,
@@ -813,6 +817,8 @@ fn expression<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
                 T::Or => Or(lhs, rhs),
 
                 T::AssertEqual => AssertEq(lhs, rhs),
+
+                T::In => In(lhs, rhs),
 
                 T::Arrow => {
                     use AssignableKind::*;
@@ -1099,6 +1105,11 @@ mod test {
         test!(expression, dict: "{1: 1}" => Dict(_));
         test!(expression, zero_set: "{}" => Set(_));
         test!(expression, zero_dict: "{:}" => Dict(_));
+
+        test!(expression, in_list: "a in [1, 2, 3]" => In(_, _));
+        test!(expression, in_set: "2 in {1, 1, 2}" => In(_, _));
+        test!(expression, in_grouping: "1 + 2 in b" => Add(_, _));
+        test!(expression, in_grouping_paren: "(1 + 2) in b" => In(_, _));
 
         test!(expression, call_simple_paren: "a()" => Get(_));
         test!(expression, call_call: "a()()" => Get(_));

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -256,17 +256,17 @@ macro_rules! raise_syntax_error {
 }
 
 macro_rules! expect {
-    ($ctx:expr, $token:pat, $( $msg:expr ),+ ) => {
+    ($ctx:expr, $( $token:pat )|+ , $( $msg:expr ),+ ) => {
         {
-            if !matches!($ctx.token(), $token) {
+            if !matches!($ctx.token(), $( $token )|* ) {
                 raise_syntax_error!($ctx, $( $msg ),*);
             }
             $ctx.skip(1)
         }
     };
 
-    ($ctx:expr, $token:pat) => {
-        expect!($ctx, $token, concat!("Expected ", stringify!($token)))
+    ($ctx:expr, $( $token:pat )|+) => {
+        expect!($ctx, $( $token )|*, concat!("Expected ", stringify!($( $token )|*)))
     };
 }
 

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -824,8 +824,6 @@ pub fn construct(tokens: &Tokens) -> Result<Module, Vec<Error>> {
 mod test {
     use crate::tokenizer::string_to_tokens;
     use super::*;
-    use ExpressionKind::*;
-    use AssignableKind::*;
 
     macro_rules! test {
         ($f:ident, $name:ident: $str:expr => $ans:pat) => {
@@ -850,6 +848,8 @@ mod test {
     // automatically.
     mod expression {
         use super::*;
+        use ExpressionKind::*;
+        use AssignableKind::*;
 
         test!(expression, value: "0" => Int(0));
         test!(expression, add: "0 + 1.0" => Add(_, _));

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -704,13 +704,13 @@ mod test {
     use TypeKind::*;
     use RuntimeType as RT;
 
-    macro_rules! test_expression {
-        ($name:ident: $str:expr => $ans:pat) => {
+    macro_rules! test {
+        ($f:ident, $name:ident: $str:expr => $ans:pat) => {
             #[test]
             fn $name () {
                 let tokens = string_to_tokens($str);
                 let path = PathBuf::from(stringify!($name));
-                let result = expression(Context::new(&tokens, &path));
+                let result = $f(Context::new(&tokens, &path));
                 assert!(result.is_ok(),
                     "\nSyntax tree test didn't parse for:\n{}\nErrs: {:?}",
                     $str,
@@ -725,60 +725,45 @@ mod test {
 
     // TODO(ed): It's really hard to write good tests, Rust refuses to deref the boxes
     // automatically.
-    test_expression!(value: "0" => Int(0));
-    test_expression!(add: "0 + 1.0" => Add(_, _));
-    test_expression!(mul: "\"abc\" * \"abc\"" => Mul(_, _));
-    test_expression!(ident: "a" => Get(Assignable { kind: Read(_), .. }));
-    test_expression!(access: "a.b" => Get(Assignable { kind: Access(_, _), .. }));
-    test_expression!(index_ident: "a[a]" => Get(Assignable { kind: Index(_, _), .. }));
-    test_expression!(index_expr: "a[1 + 2 + 3]" => Get(Assignable { kind: Index(_, _), .. }));
-    test_expression!(grouping: "(0 * 0) + 1" => Add(_, _));
-    test_expression!(tuple: "(0, 0)" => Tuple(_));
-    test_expression!(list: "[0, 0]" => List(_));
-    test_expression!(set: "{1, 1}" => Set(_));
-    test_expression!(dict: "{1: 1}" => Dict(_));
-    test_expression!(zero_set: "{}" => Set(_));
-    test_expression!(zero_dict: "{:}" => Dict(_));
+    test!(expression, value: "0" => Int(0));
+    test!(expression, add: "0 + 1.0" => Add(_, _));
+    test!(expression, mul: "\"abc\" * \"abc\"" => Mul(_, _));
+    test!(expression, ident: "a" => Get(Assignable { kind: Read(_), .. }));
+    test!(expression, access: "a.b" => Get(Assignable { kind: Access(_, _), .. }));
+    test!(expression, index_ident: "a[a]" => Get(Assignable { kind: Index(_, _), .. }));
+    test!(expression, index_expr: "a[1 + 2 + 3]" => Get(Assignable { kind: Index(_, _), .. }));
+    test!(expression, grouping: "(0 * 0) + 1" => Add(_, _));
+    test!(expression, tuple: "(0, 0)" => Tuple(_));
+    test!(expression, list: "[0, 0]" => List(_));
+    test!(expression, set: "{1, 1}" => Set(_));
+    test!(expression, dict: "{1: 1}" => Dict(_));
+    test!(expression, zero_set: "{}" => Set(_));
+    test!(expression, zero_dict: "{:}" => Dict(_));
 
-    test_expression!(call_simple_paren: "a()" => Get(_));
-    test_expression!(call_simple_bang: "a!" => Get(_));
-    test_expression!(call_chaining_paren: "a().b" => Get(_));
-    test_expression!(call_chaining_bang: "a!.b" => Get(_));
-    test_expression!(call_args_paren: "a(1, 2, 3)" => Get(_));
-    test_expression!(call_args_bang: "a! 1, 2, 3" => Get(_));
-    test_expression!(call_args_chaining_paren: "a(1, 2, 3).b" => Get(_));
-    test_expression!(call_args_chaining_paren_trailing: "a(1, 2, 3,).b" => Get(_));
-    test_expression!(call_args_chaining_bang: "a! 1, 2, 3 .b" => Get(_));
-    test_expression!(call_args_chaining_bang_trailing: "a! 1, 2, 3, .b" => Get(_));
+    test!(expression, call_simple_paren: "a()" => Get(_));
+    test!(expression, call_simple_bang: "a!" => Get(_));
+    test!(expression, call_chaining_paren: "a().b" => Get(_));
+    test!(expression, call_chaining_bang: "a!.b" => Get(_));
+    test!(expression, call_args_paren: "a(1, 2, 3)" => Get(_));
+    test!(expression, call_args_bang: "a! 1, 2, 3" => Get(_));
+    test!(expression, call_args_chaining_paren: "a(1, 2, 3).b" => Get(_));
+    test!(expression, call_args_chaining_paren_trailing: "a(1, 2, 3,).b" => Get(_));
+    test!(expression, call_args_chaining_bang: "a! 1, 2, 3 .b" => Get(_));
+    test!(expression, call_args_chaining_bang_trailing: "a! 1, 2, 3, .b" => Get(_));
 
-    test_expression!(call_arrow: "1 + 0 -> a! 2, 3" => Add(_, _));
-    test_expression!(call_arrow_grouping: "(1 + 0) -> a! 2, 3" => Get(_));
+    test!(expression, call_arrow: "1 + 0 -> a! 2, 3" => Add(_, _));
+    test!(expression, call_arrow_grouping: "(1 + 0) -> a! 2, 3" => Get(_));
 
-    macro_rules! test_type {
-        ($name:ident: $str:expr => $ans:pat) => {
-            #[test]
-            fn $name () {
-                let tokens = string_to_tokens($str);
-                let path = PathBuf::from(stringify!($name));
-                let result = parse_type(Context::new(&tokens, &path));
-                assert!(result.is_ok(),
-                    "\nSyntax tree test didn't parse for:\n{}\nErrs: {:?}",
-                    $str,
-                    result.unwrap_err().1
-                );
-                let (ctx, result) = result.unwrap();
-                assert!(matches!(result.kind, $ans), "\nExpected: {}, but got: {:?}", stringify!($ans), result);
-                assert_eq!(ctx.curr, ctx.tokens.len(), "Parsed too few or too many tokens:\n{}", $str);
-            }
-        }
-    }
-
-    test_type!(type_void: "void" => Resolved(RT::Void));
-    test_type!(type_int: "int" => Resolved(RT::Int));
-    test_type!(type_float: "float" => Resolved(RT::Float));
-    test_type!(type_str: "str" => Resolved(RT::String));
-    test_type!(type_unknown: "blargh" => Unresolved(_));
-    test_type!(type_union: "int | int" => Union(_, _));
-    test_type!(type_question: "int?" => Union(_, _));
-    test_type!(type_union_and_question: "int | void | str?" => Union(_, _));
+    test!(parse_type, type_void: "void" => Resolved(RT::Void));
+    test!(parse_type, type_int: "int" => Resolved(RT::Int));
+    test!(parse_type, type_float: "float" => Resolved(RT::Float));
+    test!(parse_type, type_str: "str" => Resolved(RT::String));
+    test!(parse_type, type_unknown: "blargh" => Unresolved(_));
+    test!(parse_type, type_union: "int | int" => Union(_, _));
+    test!(parse_type, type_question: "int?" => Union(_, _));
+    test!(parse_type, type_union_and_question: "int | void | str?" => Union(_, _));
+    test!(parse_type, type_fn_no_params: "fn ->" => Fn(_, _));
+    test!(parse_type, type_fn_one_param: "fn int? -> bool" => Fn(_, _));
+    test!(parse_type, type_fn_two_params: "fn int | void, int? -> str?" => Fn(_, _));
+    test!(parse_type, type_fn_only_ret: "fn -> bool?" => Fn(_, _));
 }

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -740,8 +740,6 @@ mod test {
     use super::*;
     use ExpressionKind::*;
     use AssignableKind::*;
-    use TypeKind::*;
-    use RuntimeType as RT;
 
     macro_rules! test {
         ($f:ident, $name:ident: $str:expr => $ans:pat) => {
@@ -764,45 +762,56 @@ mod test {
 
     // TODO(ed): It's really hard to write good tests, Rust refuses to deref the boxes
     // automatically.
-    test!(expression, value: "0" => Int(0));
-    test!(expression, add: "0 + 1.0" => Add(_, _));
-    test!(expression, mul: "\"abc\" * \"abc\"" => Mul(_, _));
-    test!(expression, ident: "a" => Get(Assignable { kind: Read(_), .. }));
-    test!(expression, access: "a.b" => Get(Assignable { kind: Access(_, _), .. }));
-    test!(expression, index_ident: "a[a]" => Get(Assignable { kind: Index(_, _), .. }));
-    test!(expression, index_expr: "a[1 + 2 + 3]" => Get(Assignable { kind: Index(_, _), .. }));
-    test!(expression, grouping: "(0 * 0) + 1" => Add(_, _));
-    test!(expression, tuple: "(0, 0)" => Tuple(_));
-    test!(expression, list: "[0, 0]" => List(_));
-    test!(expression, set: "{1, 1}" => Set(_));
-    test!(expression, dict: "{1: 1}" => Dict(_));
-    test!(expression, zero_set: "{}" => Set(_));
-    test!(expression, zero_dict: "{:}" => Dict(_));
+    mod expression {
+        use super::*;
 
-    test!(expression, call_simple_paren: "a()" => Get(_));
-    test!(expression, call_simple_bang: "a!" => Get(_));
-    test!(expression, call_chaining_paren: "a().b" => Get(_));
-    test!(expression, call_chaining_bang: "a!.b" => Get(_));
-    test!(expression, call_args_paren: "a(1, 2, 3)" => Get(_));
-    test!(expression, call_args_bang: "a! 1, 2, 3" => Get(_));
-    test!(expression, call_args_chaining_paren: "a(1, 2, 3).b" => Get(_));
-    test!(expression, call_args_chaining_paren_trailing: "a(1, 2, 3,).b" => Get(_));
-    test!(expression, call_args_chaining_bang: "a! 1, 2, 3 .b" => Get(_));
-    test!(expression, call_args_chaining_bang_trailing: "a! 1, 2, 3, .b" => Get(_));
+        test!(expression, value: "0" => Int(0));
+        test!(expression, add: "0 + 1.0" => Add(_, _));
+        test!(expression, mul: "\"abc\" * \"abc\"" => Mul(_, _));
+        test!(expression, ident: "a" => Get(Assignable { kind: Read(_), .. }));
+        test!(expression, access: "a.b" => Get(Assignable { kind: Access(_, _), .. }));
+        test!(expression, index_ident: "a[a]" => Get(Assignable { kind: Index(_, _), .. }));
+        test!(expression, index_expr: "a[1 + 2 + 3]" => Get(Assignable { kind: Index(_, _), .. }));
+        test!(expression, grouping: "(0 * 0) + 1" => Add(_, _));
+        test!(expression, tuple: "(0, 0)" => Tuple(_));
+        test!(expression, list: "[0, 0]" => List(_));
+        test!(expression, set: "{1, 1}" => Set(_));
+        test!(expression, dict: "{1: 1}" => Dict(_));
+        test!(expression, zero_set: "{}" => Set(_));
+        test!(expression, zero_dict: "{:}" => Dict(_));
 
-    test!(expression, call_arrow: "1 + 0 -> a! 2, 3" => Add(_, _));
-    test!(expression, call_arrow_grouping: "(1 + 0) -> a! 2, 3" => Get(_));
+        test!(expression, call_simple_paren: "a()" => Get(_));
+        test!(expression, call_simple_bang: "a!" => Get(_));
+        test!(expression, call_chaining_paren: "a().b" => Get(_));
+        test!(expression, call_chaining_bang: "a!.b" => Get(_));
+        test!(expression, call_args_paren: "a(1, 2, 3)" => Get(_));
+        test!(expression, call_args_bang: "a! 1, 2, 3" => Get(_));
+        test!(expression, call_args_chaining_paren: "a(1, 2, 3).b" => Get(_));
+        test!(expression, call_args_chaining_paren_trailing: "a(1, 2, 3,).b" => Get(_));
+        test!(expression, call_args_chaining_bang: "a! 1, 2, 3 .b" => Get(_));
+        test!(expression, call_args_chaining_bang_trailing: "a! 1, 2, 3, .b" => Get(_));
 
-    test!(parse_type, type_void: "void" => Resolved(RT::Void));
-    test!(parse_type, type_int: "int" => Resolved(RT::Int));
-    test!(parse_type, type_float: "float" => Resolved(RT::Float));
-    test!(parse_type, type_str: "str" => Resolved(RT::String));
-    test!(parse_type, type_unknown: "blargh" => Unresolved(_));
-    test!(parse_type, type_union: "int | int" => Union(_, _));
-    test!(parse_type, type_question: "int?" => Union(_, _));
-    test!(parse_type, type_union_and_question: "int | void | str?" => Union(_, _));
-    test!(parse_type, type_fn_no_params: "fn ->" => Fn(_, _));
-    test!(parse_type, type_fn_one_param: "fn int? -> bool" => Fn(_, _));
-    test!(parse_type, type_fn_two_params: "fn int | void, int? -> str?" => Fn(_, _));
-    test!(parse_type, type_fn_only_ret: "fn -> bool?" => Fn(_, _));
+        test!(expression, call_arrow: "1 + 0 -> a! 2, 3" => Add(_, _));
+        test!(expression, call_arrow_grouping: "(1 + 0) -> a! 2, 3" => Get(_));
+    }
+
+    mod parse_type {
+        use super::*;
+        use TypeKind::*;
+        use RuntimeType as RT;
+
+        test!(parse_type, type_void: "void" => Resolved(RT::Void));
+        test!(parse_type, type_int: "int" => Resolved(RT::Int));
+        test!(parse_type, type_float: "float" => Resolved(RT::Float));
+        test!(parse_type, type_str: "str" => Resolved(RT::String));
+        test!(parse_type, type_unknown: "blargh" => Unresolved(_));
+        test!(parse_type, type_union: "int | int" => Union(_, _));
+        test!(parse_type, type_question: "int?" => Union(_, _));
+        test!(parse_type, type_union_and_question: "int | void | str?" => Union(_, _));
+
+        test!(parse_type, type_fn_no_params: "fn ->" => Fn(_, _));
+        test!(parse_type, type_fn_one_param: "fn int? -> bool" => Fn(_, _));
+        test!(parse_type, type_fn_two_params: "fn int | void, int? -> str?" => Fn(_, _));
+        test!(parse_type, type_fn_only_ret: "fn -> bool?" => Fn(_, _));
+    }
 }

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -456,7 +456,11 @@ fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
 
         [(T::Ret, _), ..] => {
             let ctx = ctx.skip(1);
-            let (ctx, value) = expression(ctx)?;
+            let (ctx, value) = if matches!(ctx.token(), T::Newline) {
+                (ctx, Expression { span: ctx.span(), kind: ExpressionKind::Nil })
+            } else {
+                expression(ctx)?
+            };
             (ctx, Ret { value })
         }
 
@@ -1242,6 +1246,7 @@ mod test {
         test!(statement, statement_if_else: "if 1 { print a } else { print b }" => _);
         test!(statement, statement_loop: "loop 1 { print a }" => _);
         test!(statement, statement_ret: "ret 1 + 1" => _);
+        test!(statement, statement_ret_newline: "ret \n" => _);
         test!(statement, statement_unreach: "<!>" => _);
         test!(statement, statement_blob_empty: "A :: blob {}" => _);
         test!(statement, statement_blob_comma: "A :: blob { a: int, b: int }" => _);

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -288,7 +288,7 @@ macro_rules! expect {
 }
 
 macro_rules! skip_if {
-    ($ctx:expr, $( $token:pat )|+ ) => {
+    ($ctx:expr, $( $token:pat )|+) => {
         {
             if matches!($ctx.token(), $( $token )|* ) {
                 $ctx.skip(1)

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -1364,6 +1364,20 @@ mod test {
         test!(expression, simple: "fn -> {}" => _);
         test!(expression, argument: "fn a: int -> int ret a + 1" => _);
 
+        test!(expression, booleans: "true && false || !false" => _);
+        test!(expression, bool_and: "true && a" => _);
+        test!(expression, bool_or: "a || false" => _);
+        test!(expression, bool_neg: "!a" => _);
+
+        test!(expression, cmp_eq: "a == b" => _);
+        test!(expression, cmp_leq: "a <= b" => _);
+        test!(expression, cmp_geq: "a >= b" => _);
+        test!(expression, cmp_gt: "a > b" => _);
+        test!(expression, cmp_lt: "a < b" => _);
+        test!(expression, neg: "-a" => _);
+
+        test!(expression, expr: "-a + b < 3 + true && false" => _);
+
         test!(expression, void_simple: "fn {}" => _);
         test!(expression, void_argument: "fn a: int { ret a + 1 }" => _);
     }

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -1,3 +1,6 @@
+// TODO(ed): Remove me
+#![allow(unused)]
+
 use std::path::{PathBuf, Path};
 use std::collections::HashMap;
 use crate::error::Error;
@@ -279,7 +282,6 @@ macro_rules! skip_if {
 }
 
 fn expression<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
-    use T as T;
     use ExpressionKind::*;
 
     fn function<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -669,7 +669,7 @@ mod test {
                     result.unwrap_err().1
                 );
                 let (ctx, result) = result.unwrap();
-                assert!(matches!(result, $ans), "\nExpected: {}, but got: {:?}", stringify!($ans), result);
+                assert!(matches!(result.kind, $ans), "\nExpected: {}, but got: {:?}", stringify!($ans), result);
                 assert_eq!(ctx.curr, ctx.tokens.len(), "Ate past the end of the buffer for:\n{}", $str);
             }
         }
@@ -677,40 +677,32 @@ mod test {
 
     // TODO(ed): It's really hard to write good tests, Rust refuses to deref the boxes
     // automatically.
-    test_expression!(simple_expr: "0" => Expression { kind: Int(0), .. });
-    test_expression!(simple_add: "0 + 1.0" => Expression { kind: Add(_, _), ..  });
-    test_expression!(simple_mul: "\"abc\" * \"abc\"" => Expression { kind: Mul(_, _), ..  });
-    test_expression!(simple_ident: "a" => Expression {
-        kind: Get(Assignable { kind: Read(_), .. }),
-        ..
-    });
-    test_expression!(simple_access: "a.b" => Expression {
-        kind: Get(Assignable { kind: Access(_, _), .. }), ..
-    });
-    test_expression!(simple_index_ident: "a[a]" => Expression {
-        kind: Get(Assignable { kind: Index(_, _), .. }), ..
-    });
-    test_expression!(simple_index_expr: "a[1 + 2 + 3]" => Expression {
-        kind: Get(Assignable { kind: Index(_, _), .. }), ..
-    });
-    test_expression!(simple_grouping: "(0 * 0) + 1" => Expression { kind: Add(_, _), .. });
-    test_expression!(simple_tuple: "(0, 0)" => Expression { kind: Tuple(_), .. });
-    test_expression!(simple_list: "[0, 0]" => Expression { kind: List(_), .. });
-    test_expression!(simple_set: "{1, 1}" => Expression { kind: Set(_), .. });
-    test_expression!(simple_dict: "{1: 1}" => Expression { kind: Dict(_), .. });
-    test_expression!(zero_set: "{}" => Expression { kind: Set(_), .. });
-    test_expression!(zero_dict: "{:}" => Expression { kind: Dict(_), .. });
+    test_expression!(simple_expr: "0" => Int(0));
+    test_expression!(simple_add: "0 + 1.0" => Add(_, _));
+    test_expression!(simple_mul: "\"abc\" * \"abc\"" => Mul(_, _));
+    test_expression!(simple_ident: "a" => Get(Assignable { kind: Read(_), .. }));
+    test_expression!(simple_access: "a.b" => Get(Assignable { kind: Access(_, _), .. }));
+    test_expression!(simple_index_ident: "a[a]" => Get(Assignable { kind: Index(_, _), .. }));
+    test_expression!(simple_index_expr: "a[1 + 2 + 3]" => Get(Assignable { kind: Index(_, _), .. }));
+    test_expression!(simple_grouping: "(0 * 0) + 1" => Add(_, _));
+    test_expression!(simple_tuple: "(0, 0)" => Tuple(_));
+    test_expression!(simple_list: "[0, 0]" => List(_));
+    test_expression!(simple_set: "{1, 1}" => Set(_));
+    test_expression!(simple_dict: "{1: 1}" => Dict(_));
+    test_expression!(zero_set: "{}" => Set(_));
+    test_expression!(zero_dict: "{:}" => Dict(_));
 
-    test_expression!(call_simple_paren: "a()" => Expression { kind: Get(_), .. });
-    test_expression!(call_simple_bang: "a!" => Expression { kind: Get(_), .. });
-    test_expression!(call_chaining_paren: "a().b" => Expression { kind: Get(_), .. });
-    test_expression!(call_chaining_bang: "a!.b" => Expression { kind: Get(_), .. });
-    test_expression!(call_args_paren: "a(1, 2, 3)" => Expression { kind: Get(_), .. });
-    test_expression!(call_args_bang: "a! 1, 2, 3" => Expression { kind: Get(_), .. });
-    test_expression!(call_args_chaining_paren: "a(1, 2, 3).b" => Expression { kind: Get(_), .. });
-    test_expression!(call_args_chaining_paren_trailing: "a(1, 2, 3,).b" => Expression { kind: Get(_), .. });
-    test_expression!(call_args_chaining_bang: "a! 1, 2, 3 .b" => Expression { kind: Get(_), .. });
-    test_expression!(call_args_chaining_bang_trailing: "a! 1, 2, 3, .b" => Expression { kind: Get(_), .. });
+    test_expression!(call_simple_paren: "a()" => Get(_));
+    test_expression!(call_simple_bang: "a!" => Get(_));
+    test_expression!(call_chaining_paren: "a().b" => Get(_));
+    test_expression!(call_chaining_bang: "a!.b" => Get(_));
+    test_expression!(call_args_paren: "a(1, 2, 3)" => Get(_));
+    test_expression!(call_args_bang: "a! 1, 2, 3" => Get(_));
+    test_expression!(call_args_chaining_paren: "a(1, 2, 3).b" => Get(_));
+    test_expression!(call_args_chaining_paren_trailing: "a(1, 2, 3,).b" => Get(_));
+    test_expression!(call_args_chaining_bang: "a! 1, 2, 3 .b" => Get(_));
+    test_expression!(call_args_chaining_bang_trailing: "a! 1, 2, 3, .b" => Get(_));
 
-    test_expression!(call_arrow: "1 + 0 -> a! 2, 3" => Expression { kind: Add(_), .. });
+    test_expression!(call_arrow: "1 + 0 -> a! 2, 3" => Add(_, _));
+    test_expression!(call_arrow_grouping: "(1 + 0) -> a! 2, 3" => Get(_));
 }

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -282,7 +282,7 @@ macro_rules! expect {
         }
     };
 
-    ($ctx:expr, $( $token:pat )|+) => {
+    ($ctx:expr, $( $token:pat )|+ ) => {
         expect!($ctx, $( $token )|*, concat!("Expected ", stringify!($( $token )|*)))
     };
 }

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 use std::collections::HashMap;
+use crate::error::Error;
+use crate::tokenizer::TokenStream;
 use super::Type as runtimeType;
 
 #[derive(Debug, Copy, Clone)]
@@ -185,4 +187,8 @@ pub enum TypeKind {
 pub struct Type {
     span: Span,
     kind: TypeKind,
+}
+
+pub fn construct(tokens: TokenStream) -> Result<Prog, Vec<Error>> {
+    Err(Vec::new())
 }

--- a/src/syntree.rs
+++ b/src/syntree.rs
@@ -388,7 +388,7 @@ fn parse_type<'t>(ctx: Context<'t>) -> ParseResult<'t, Type> {
                         ctx = _ctx;
                         types.push(param);
 
-                        ctx = if matches!(ctx.token(), T::Comma | T::LeftParen) {
+                        ctx = if matches!(ctx.token(), T::Comma | T::RightParen) {
                             skip_if!(ctx, T::Comma)
                         } else {
                             raise_syntax_error!(ctx, "Expected ',' or ')' after tuple field")
@@ -899,5 +899,8 @@ mod test {
         test!(parse_type, type_fn_one_param: "fn int? -> bool" => Fn(_, _));
         test!(parse_type, type_fn_two_params: "fn int | void, int? -> str?" => Fn(_, _));
         test!(parse_type, type_fn_only_ret: "fn -> bool?" => Fn(_, _));
+
+        test!(parse_type, type_tuple_one: "(int)" => Tuple(_));
+        test!(parse_type, type_tuple_complex: "(int | float?, str, str,)" => Tuple(_));
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -32,8 +32,8 @@ pub enum Token {
     Continue,
     #[token("in")]
     In,
-    // #[token("loop")]
-    // Loop,
+    #[token("loop")]
+    Loop,
     #[token("blob")]
     Blob,
 


### PR DESCRIPTION
21-06-02
I've matched the old syntax as tightly as possible - there are however some small TODOs that need 
addressing, but I would like to test them out before removing them.

The parser doesn't find any syntax errors in test-suite we have made, except for the for-loops.
Other than that the parser seams to work pretty great! I can't think of anything more to test
or anything more to remove, so I think this is done for now.

For some highlevel documentation, there are 4 functions to worry about:
 - statement, does all statement parsing
 - expression, has a lot of internal functions for passing around expressions, but that is only available internally
 - parse_type, parses types with some fancy recursion (a lot simpler than the old one)
 - function, parsing functions, it's a pretty big deal with functions, but it is a lot simpler than it used to be
 