### PR TITLE
Implicit duclktyping

### DIFF
--- a/progs/tests/blob/field_get_faulty.sy
+++ b/progs/tests/blob/field_get_faulty.sy
@@ -12,5 +12,3 @@ f :: fn a:int -> int {
 // error: #UnknownField(_, _)
 // error: #UnknownField(_, _)
 // error: #UnknownField(_, _)
-// error: #ArgumentType(_, _)
-// error: #TypeMismatch(_, _)

--- a/progs/tests/blob/non_null_fields_faulty.sy
+++ b/progs/tests/blob/non_null_fields_faulty.sy
@@ -7,5 +7,5 @@ start :: fn {
     print a.a
 }
 
-// error: #FieldTypeMismatch(_, _, _, _)
+// error: #FieldTypeMismatch(_, _, _, _, _)
 // error: #TypeError(_, _)

--- a/progs/tests/ducktyping/simple.sy
+++ b/progs/tests/ducktyping/simple.sy
@@ -1,0 +1,11 @@
+A :: blob { a: int }
+B :: blob { a: int, b: int }
+
+f :: fn a: A -> int { ret a.a }
+
+start :: fn {
+	b :: B { a: 0, b: 1 }
+	f(b) <=> 0
+}
+
+

--- a/progs/tests/ducktyping/simple_faulty.sy
+++ b/progs/tests/ducktyping/simple_faulty.sy
@@ -1,0 +1,13 @@
+A :: blob { a: int }
+B :: blob { a: int, b: int }
+
+f :: fn b: B -> int { ret b.b }
+
+start :: fn {
+	a :: A { a: 0 }
+	f(a) <=> 0
+}
+
+// error: #ArgumentType(_, _, _)
+// error: #TypeError(_, _)
+// error: #TypeMismatch(_, _)

--- a/sylt-common/src/lib.rs
+++ b/sylt-common/src/lib.rs
@@ -18,4 +18,9 @@ pub use value::{IterFn, MatchableValue, Value};
 
 /// A linkable external function. Created either manually or using
 /// [sylt_macro::extern_function].
-pub type RustFunction = fn(&[Value], bool) -> Result<Value, error::RuntimeError>;
+pub type RustFunction = fn(&[Value], RuntimeContext) -> Result<Value, error::RuntimeError>;
+
+pub struct RuntimeContext<'t> {
+    pub typecheck: bool,
+    pub blobs: &'t [Blob],
+}

--- a/sylt-machine/src/lib.rs
+++ b/sylt-machine/src/lib.rs
@@ -4,7 +4,7 @@ use std::collections::{hash_map::Entry, HashMap, HashSet};
 use std::fmt::Debug;
 use sylt_common::error::{Error, RuntimeError, RuntimePhase};
 use sylt_common::rc::Rc;
-use sylt_common::{Block, BlockLinkState, Blob, IterFn, Op, Prog, RustFunction, Type, UpValue, Value};
+use sylt_common::{Block, BlockLinkState, Blob, IterFn, Op, Prog, RuntimeContext, RustFunction, Type, UpValue, Value};
 
 macro_rules! error {
     ( $thing:expr, $kind:expr) => {
@@ -692,7 +692,11 @@ impl VM {
                     }
                     Value::ExternFunction(slot) => {
                         let extern_func = self.extern_functions[slot];
-                        let res = match extern_func(&self.stack[new_base + 1..], false) {
+                        let ctx = RuntimeContext {
+                            typecheck: false,
+                            blobs: &self.blobs,
+                        };
+                        let res = match extern_func(&self.stack[new_base + 1..], ctx) {
                             Ok(value) => value,
                             Err(ek) => error!(self, ek, "Failed in external function"),
                         };

--- a/sylt-std/src/lib.rs
+++ b/sylt-std/src/lib.rs
@@ -1,3 +1,4 @@
 #[cfg(feature = "lingon")]
 pub mod lingon;
 pub mod sylt;
+

--- a/sylt-std/src/lingon.rs
+++ b/sylt-std/src/lingon.rs
@@ -5,7 +5,7 @@ use lingon::renderer::{Rect, Sprite, Transform, Tint};
 use sylt_common::error::RuntimeError;
 use sylt_common::rc::Rc;
 use std::{path::PathBuf, sync::{Arc, Mutex}};
-use sylt_common::{Value::{self, *}, Type};
+use sylt_common::{Value::{self, *}, Type, RuntimeContext};
 
 // Errors are important, they should be easy to write!
 macro_rules! error {
@@ -882,8 +882,8 @@ pub fn sylt_str(s: &str) -> Value {
 #[sylt_macro::sylt_doc(l_load_image, "Loads an image and turns it into a sprite sheet",
   [One(String(path))] Type::Tuple)]
 #[sylt_macro::sylt_link(l_load_image, "sylt_std::lingon")]
-pub fn l_load_image(values: &[Value], typecheck: bool) -> Result<Value, RuntimeError> {
-    match (values, typecheck) {
+pub fn l_load_image<'t>(values: &[Value], ctx: RuntimeContext<'t>) -> Result<Value, RuntimeError> {
+    match (values, ctx.typecheck) {
         ([String(path), tilesize], false) => {
             let game = game!();
             let path = PathBuf::from(path.as_ref());
@@ -910,8 +910,8 @@ pub fn l_load_image(values: &[Value], typecheck: bool) -> Result<Value, RuntimeE
   "Loads a sound and lets you play it using <a href='l_audio_play'>l_audio_play</a>",
   [One(String(path))] Type::Tuple)]
 #[sylt_macro::sylt_link(l_load_audio, "sylt_std::lingon")]
-pub fn l_load_audio(values: &[Value], typecheck: bool) -> Result<Value, RuntimeError> {
-    match (values, typecheck) {
+pub fn l_load_audio<'t>(values: &[Value], ctx: RuntimeContext<'t>) -> Result<Value, RuntimeError> {
+    match (values, ctx.typecheck) {
         ([String(path)], false) => {
             let game = game!();
             let path = PathBuf::from(path.as_ref());

--- a/sylt-std/src/sylt.rs
+++ b/sylt-std/src/sylt.rs
@@ -4,11 +4,11 @@ use owo_colors::OwoColorize;
 use sylt_common::error::RuntimeError;
 use sylt_common::rc::Rc;
 use std::cell::RefCell;
-use sylt_common::{Type, Value};
+use sylt_common::{Type, Value, Blob, RuntimeContext};
 
 #[sylt_macro::sylt_doc(dbg, "Writes the type and value of anything you enter", [One(Value(val))] Type::Void)]
 #[sylt_macro::sylt_link(dbg, "sylt_std::sylt")]
-pub fn dbg(values: &[Value], _typecheck: bool) -> Result<Value, RuntimeError> {
+pub fn dbg<'t>(values: &[Value], _ctx: RuntimeContext<'t>) -> Result<Value, RuntimeError> {
     println!(
         "{}: {:?}, {:?}",
         "DBG".purple(),
@@ -20,8 +20,8 @@ pub fn dbg(values: &[Value], _typecheck: bool) -> Result<Value, RuntimeError> {
 
 #[sylt_macro::sylt_doc(push, "Appends an element to the end of a list", [One(List(ls)), One(Value(val))] Type::Void)]
 #[sylt_macro::sylt_link(push, "sylt_std::sylt")]
-pub fn push(values: &[Value], typecheck: bool) -> Result<Value, RuntimeError> {
-    match (values, typecheck) {
+pub fn push<'t>(values: &[Value], ctx: RuntimeContext<'t>) -> Result<Value, RuntimeError> {
+    match (values, ctx.typecheck) {
         ([Value::List(ls), v], true) => {
             let ls = ls.borrow();
             assert!(ls.len() == 1);
@@ -47,8 +47,8 @@ pub fn push(values: &[Value], typecheck: bool) -> Result<Value, RuntimeError> {
 
 #[sylt_macro::sylt_doc(clear, "Removes all elements from the list", [One(List(ls))] Type::Void)]
 #[sylt_macro::sylt_link(clear, "sylt_std::sylt")]
-pub fn clear(values: &[Value], typecheck: bool) -> Result<Value, RuntimeError> {
-    match (values, typecheck) {
+pub fn clear<'t>(values: &[Value], ctx: RuntimeContext<'t>) -> Result<Value, RuntimeError> {
+    match (values, ctx.typecheck) {
         ([Value::List(ls)], _) => {
             ls.borrow_mut().clear();
             Ok(Value::Nil)
@@ -63,8 +63,8 @@ pub fn clear(values: &[Value], typecheck: bool) -> Result<Value, RuntimeError> {
 
 #[sylt_macro::sylt_doc(prepend, "Adds an element to the start of a list", [One(List(ls)), One(Value(val))] Type::Void)]
 #[sylt_macro::sylt_link(prepend, "sylt_std::sylt")]
-pub fn prepend(values: &[Value], typecheck: bool) -> Result<Value, RuntimeError> {
-    match (values, typecheck) {
+pub fn prepend<'t>(values: &[Value], ctx: RuntimeContext<'t>) -> Result<Value, RuntimeError> {
+    match (values, ctx.typecheck) {
         ([Value::List(ls), v], true) => {
             let ls = &ls.borrow();
             assert!(ls.len() == 1);
@@ -90,7 +90,7 @@ pub fn prepend(values: &[Value], typecheck: bool) -> Result<Value, RuntimeError>
 
 #[sylt_macro::sylt_doc(len, "Gives the length of tuples and lists", [One(Tuple(ls))] Type::Int, [One(List(ls))] Type::Int)]
 #[sylt_macro::sylt_link(len, "sylt_std::sylt")]
-pub fn len(values: &[Value], _: bool) -> Result<Value, RuntimeError> {
+pub fn len<'t>(values: &[Value], _: RuntimeContext) -> Result<Value, RuntimeError> {
     match values {
         [Value::Tuple(ls)] => {
             Ok(Value::Int(ls.len() as i64))
@@ -219,10 +219,10 @@ sylt_macro::extern_function!(
 
 
 
-pub fn union_type(a: Type, b: Type) -> Type{
-    if a.fits(&b) {
+pub fn union_type<'t>(a: Type, b: Type, blobs: &[Blob]) -> Type{
+    if a.fits(&b, blobs) {
         a
-    } else if b.fits(&a) {
+    } else if b.fits(&a, blobs) {
         b
     } else {
         match (a, b) {
@@ -243,13 +243,13 @@ pub fn union_type(a: Type, b: Type) -> Type{
 
 #[sylt_macro::sylt_doc(pop, "Removes the last element in the list, and returns it", [One(List(l))] Type::Value)]
 #[sylt_macro::sylt_link(pop, "sylt_std::sylt")]
-pub fn pop(values: &[Value], typecheck: bool) -> Result<Value, RuntimeError> {
-    match (values, typecheck) {
+pub fn pop<'t>(values: &[Value], ctx: RuntimeContext<'t>) -> Result<Value, RuntimeError> {
+    match (values, ctx.typecheck) {
         ([Value::List(ls)], true) => {
             let ls = &ls.borrow();
             // TODO(ed): Write correct typing
             let ls = Type::from(&ls[0]);
-            let ret = union_type(ls, Type::Void);
+            let ret = union_type(ls, Type::Void, ctx.blobs);
             Ok(Value::from(ret))
         }
         ([Value::List(ls)], false) => {
@@ -266,7 +266,7 @@ pub fn pop(values: &[Value], typecheck: bool) -> Result<Value, RuntimeError> {
 
 #[sylt_macro::sylt_doc(inf, "Returns an infinite iterator, spitting out the value you give it", [One(Value(val))] Type::Iter)]
 #[sylt_macro::sylt_link(inf, "sylt_std::sylt")]
-pub fn inf(values: &[Value], _typecheck: bool) -> Result<Value, RuntimeError> {
+pub fn inf<'t>(values: &[Value], _ctx: RuntimeContext<'t>) -> Result<Value, RuntimeError> {
     match values {
         [x] => {
             let t: Type = Type::from(&*x);

--- a/sylt-std/src/sylt.rs
+++ b/sylt-std/src/sylt.rs
@@ -220,9 +220,9 @@ sylt_macro::extern_function!(
 
 
 pub fn union_type<'t>(a: Type, b: Type, blobs: &[Blob]) -> Type{
-    if a.fits(&b, blobs) {
+    if a.fits(&b, blobs).is_ok() {
         a
-    } else if b.fits(&a, blobs) {
+    } else if b.fits(&a, blobs).is_ok() {
         b
     } else {
         match (a, b) {

--- a/sylt-typechecker/src/lib.rs
+++ b/sylt-typechecker/src/lib.rs
@@ -224,11 +224,12 @@ impl VM {
             Op::AssignLocal(slot) => {
                 let current = self.stack[slot].clone();
                 let given = self.pop();
-                if !current.fits(&given, &prog.blobs) {
+                if let Err(msg) = current.fits(&given, &prog.blobs) {
                     error!(
                         self,
                         RuntimeError::TypeMismatch(current, given),
-                        "Cannot assign to different type"
+                        "Failed to assign. {}",
+                        msg
                     );
                 }
 
@@ -255,11 +256,12 @@ impl VM {
             Op::AssignGlobal(slot) => {
                 let current = self.global_types[slot].clone();
                 let given = self.pop();
-                if !current.fits(&given, &prog.blobs) {
+                if let Err(msg) = current.fits(&given, &prog.blobs) {
                     error!(
                         self,
                         RuntimeError::TypeMismatch(current, given),
-                        "Cannot assign to different type"
+                        "Failed to assign. {}",
+                        msg
                     );
                 }
             }
@@ -382,11 +384,12 @@ impl VM {
             Op::AssignUpvalue(slot) => {
                 let current = self.upvalues.get(slot).unwrap().clone();
                 let up = self.pop();
-                if !current.fits(&up, &prog.blobs) {
+                if let Err(msg) = current.fits(&up, &prog.blobs) {
                     error!(
                         self,
                         RuntimeError::TypeMismatch(up, current),
-                        "Captured varibles type doesn't match upvalue"
+                        "Captured varibles type doesn't match upvalue type. {}",
+                        msg
                     );
                 }
                 if matches!(current, Type::Unknown) {
@@ -419,16 +422,18 @@ impl VM {
                 let top_type = self.stack.last().unwrap().clone();
                 match (ty, top_type) {
                     (Type::Unknown, top_type) if top_type != Type::Unknown => {}
-                    (a, b) if a.fits(&b, &prog.blobs) => {
-                        let last = self.stack.len() - 1;
-                        self.stack[last] = a;
-                    }
                     (a, b) => {
-                        error!(
-                            self,
-                            RuntimeError::TypeMismatch(a.clone(), b),
-                            "Cannot assign mismatching types"
-                        );
+                        if let Err(msg) = a.fits(&b, &prog.blobs) {
+                            error!(
+                                self,
+                                RuntimeError::TypeMismatch(a.clone(), b),
+                                "Cannot define mismatching types. {}",
+                                msg
+                            );
+                        } else {
+                            let last = self.stack.len() - 1;
+                            self.stack[last] = a;
+                        }
                     }
                 }
             }
@@ -542,17 +547,24 @@ impl VM {
 
             Op::GetIndex => {
                 match self.poppop() {
-                    (Type::List(a), b) if b.fits(&Type::Int, &prog.blobs) => {
+                    (Type::List(a), b) if b.fits(&Type::Int, &prog.blobs).is_ok() => {
                         self.push((*a).clone());
                     }
-                    (Type::Tuple(a), b) if b.fits(&Type::Int, &prog.blobs) => {
+                    (Type::Tuple(a), b) if b.fits(&Type::Int, &prog.blobs).is_ok() => {
                         self.push(Type::Union(a.iter().cloned().collect()));
                     }
-                    (Type::Dict(k, v), i) if k.fits(&i, &prog.blobs) => {
+                    (Type::Dict(k, v), i) if k.fits(&i, &prog.blobs).is_ok() => {
                         self.push((*v).clone());
                     }
-                    _ => {
+                    (a, b) => {
                         self.push(Type::Void);
+                        error!(
+                            self,
+                            RuntimeError::TypeError(op, vec![]),
+                            "Failed to index '{:?}' with '{:?}'",
+                            a,
+                            b
+                        );
                     }
                 }
             }
@@ -564,29 +576,33 @@ impl VM {
                 match (indexable, slot, value) {
                     (Type::List(v), Type::Int, n) => match (v.as_ref(), &n) {
                         (Type::Unknown, top_type) if top_type != &Type::Unknown => {}
-                        (a, b) if a.fits(b, &prog.blobs) => {}
                         (a, b) => {
-                            error!(
-                                self,
-                                RuntimeError::TypeMismatch(a.clone(), b.clone()),
-                                "Cannot assign mismatching types"
-                            );
+                            if let Err(msg) = a.fits(b, &prog.blobs) {
+                                error!(
+                                    self,
+                                    RuntimeError::TypeMismatch(a.clone(), b.clone()),
+                                    "Cannot assign mismatching types. {}",
+                                    msg
+                                );
+                            }
                         }
                     },
                     (Type::Dict(k, v), i, n) => {
-                        if !k.fits(&i, &prog.blobs) {
+                        if let Err(msg) = k.fits(&i, &prog.blobs) {
                             error!(
                                 self,
-                                RuntimeError::TypeMismatch(k.as_ref().clone(), i),
-                                "Cannot index mismatching types"
+                                RuntimeError::TypeMismatch(*k.clone(), i.clone()),
+                                "Cannot index with missmatching types. {}",
+                                msg
                             );
                         }
 
-                        if !v.fits(&n, &prog.blobs) {
+                        if let Err(msg) = v.fits(&n, &prog.blobs) {
                             error!(
                                 self,
-                                RuntimeError::TypeMismatch(v.as_ref().clone(), n),
-                                "Cannot assign mismatching types"
+                                RuntimeError::TypeMismatch(*v.clone(), n.clone()),
+                                "Cannot assign with missmatching types. {}",
+                                msg
                             );
                         }
                     }
@@ -605,11 +621,12 @@ impl VM {
                 match (Type::from(container), Type::from(element)) {
                     (Type::List(v), e) | (Type::Set(v), e) | (Type::Dict(v, _), e) => {
                         self.push(Type::Bool);
-                        if !v.fits(&e, &prog.blobs) {
+                        if let Err(msg) = v.fits(&e, &prog.blobs) {
                             error!(
                                 self,
                                 RuntimeError::TypeMismatch(v.as_ref().clone(), e),
-                                "Container does not contain the type"
+                                "Container does not contain the type. {}",
+                                msg
                             );
                         }
                     }
@@ -641,14 +658,16 @@ impl VM {
 
                             for (field, ty) in values.iter() {
                                 match blob.fields.get(field) {
-                                    Some(given_ty) if given_ty.fits(ty, &prog.blobs) => {}
                                     Some(given_ty) => {
-                                        return Err(RuntimeError::FieldTypeMismatch(
-                                                blob.name.clone(),
-                                                field.clone(),
-                                                ty.clone(),
-                                                given_ty.clone(),
-                                        ));
+                                        if let Err(msg) = given_ty.fits(ty, &prog.blobs) {
+                                            return Err(RuntimeError::FieldTypeMismatch(
+                                                    blob.name.clone(),
+                                                    field.clone(),
+                                                    ty.clone(),
+                                                    given_ty.clone(),
+                                                    msg,
+                                            ));
+                                        }
                                     }
                                     None => {
                                         return Err(RuntimeError::UnknownField(
@@ -661,23 +680,27 @@ impl VM {
 
                             for (field, ty) in blob.fields.iter() {
                                 match (values.get(field), ty) {
-                                    (Some(t), ty) if ty.fits(t, &prog.blobs) => {}
                                     (Some(t), ty) => {
-                                        return Err(RuntimeError::FieldTypeMismatch(
-                                                blob.name.clone(),
-                                                field.clone(),
-                                                ty.clone(),
-                                                t.clone(),
-                                        ))
+                                        if let Err(msg) = ty.fits(t, &prog.blobs) {
+                                            return Err(RuntimeError::FieldTypeMismatch(
+                                                    blob.name.clone(),
+                                                    field.clone(),
+                                                    ty.clone(),
+                                                    t.clone(),
+                                                    msg,
+                                            ));
+                                        }
                                     }
-                                    (None, ty) if ty.fits(&Type::Void, &prog.blobs) => {}
                                     (None, ty) => {
-                                        return Err(RuntimeError::FieldTypeMismatch(
-                                                blob.name.clone(),
-                                                field.clone(),
-                                                ty.clone(),
-                                                Type::Void,
-                                        ));
+                                        if let Err(msg) = ty.fits(&Type::Void, &prog.blobs) {
+                                            return Err(RuntimeError::FieldTypeMismatch(
+                                                    blob.name.clone(),
+                                                    field.clone(),
+                                                    ty.clone(),
+                                                    Type::Void,
+                                                    msg,
+                                            ));
+                                        }
                                     }
                                 }
                             }
@@ -686,11 +709,12 @@ impl VM {
                         }
 
                         Type::Function(fargs, fret) => {
-                            if fargs.iter().zip(args.iter()).all(|(a, b)| a.fits(b, &prog.blobs)) {
-                                Ok((**fret).clone())
-                            } else {
-                                Err(RuntimeError::ArgumentType(fargs.clone(), args))
+                            for (a, b) in fargs.iter().zip(args.iter()) {
+                                if let Err(msg) = a.fits(b, &prog.blobs) {
+                                    return Err(RuntimeError::ArgumentType(fargs.clone(), args, msg));
+                                }
                             }
+                            Ok((**fret).clone())
                         }
 
                         Type::ExternFunction(slot) => {

--- a/sylt_macro/src/lib.rs
+++ b/sylt_macro/src/lib.rs
@@ -101,14 +101,14 @@ pub fn extern_function(tokens: proc_macro::TokenStream) -> proc_macro::TokenStre
         #[sylt_macro::sylt_link(#link_name, #module)]
         pub fn #function (
             __values: &[sylt_common::Value],
-            __typecheck: bool
+            __ctx: sylt_common::RuntimeContext
         ) -> ::std::result::Result<sylt_common::Value, sylt_common::error::RuntimeError>
         {
             use sylt_common::MatchableValue::*;
             use sylt_common::RustFunction;
             use sylt_common::Value::*;
             use sylt_common::value::make_matchable;
-            if __typecheck {
+            if __ctx.typecheck {
                 let matching: Vec<_> = __values.iter().map(make_matchable).collect();
                 #[allow(unused_variables)]
                 match matching.as_slice() {


### PR DESCRIPTION
The type errors are now clearer when it comes to composite types.
(We need to do something smart about the errors thought, not all of them are neatly formatted right now, maybe break at newlines when printing them?)

I only added very basic tests, because I find it kinda dull. But we probably need more tests here.

The change isn't that large, but it touches a lot of places.
