### PR TITLE
Allow newlines in more places

### DIFF
--- a/progs/tests/blob/ambiguous_if.sy
+++ b/progs/tests/blob/ambiguous_if.sy
@@ -1,11 +1,11 @@
 A :: blob {
-    a: int
-    b: [int]
+    a: int,
+    b: [int],
 }
 
 start :: fn {
     a := A {
-        b: [1, 2]
-        a: 0
+        b: [1, 2],
+        a: 0,
     }
 }

--- a/progs/tests/blob/faulty_num_arguments.sy
+++ b/progs/tests/blob/faulty_num_arguments.sy
@@ -1,6 +1,6 @@
 A :: blob {
-    a: int
-    b: int
+    a: int,
+    b: int,
 }
 
 start :: fn {

--- a/progs/tests/blob/multiple_fields.sy
+++ b/progs/tests/blob/multiple_fields.sy
@@ -1,6 +1,6 @@
 A :: blob {
-    a: int
-    b: int
+    a: int,
+    b: int,
 }
 
 start :: fn {

--- a/progs/tests/blob/non_null_fields_faulty.sy
+++ b/progs/tests/blob/non_null_fields_faulty.sy
@@ -1,5 +1,5 @@
 A :: blob {
-    a: int
+    a: int,
 }
 
 start :: fn {

--- a/progs/tests/blob/null_fields.sy
+++ b/progs/tests/blob/null_fields.sy
@@ -1,5 +1,5 @@
 A :: blob {
-    a: int?
+    a: int?,
 }
 
 start :: fn {

--- a/progs/tests/blob/null_fields_faulty.sy
+++ b/progs/tests/blob/null_fields_faulty.sy
@@ -2,7 +2,7 @@ A :: blob {
 }
 
 B :: blob {
-    a: int?
+    a: int?,
 }
 
 start :: fn {

--- a/progs/tests/blob/simple.sy
+++ b/progs/tests/blob/simple.sy
@@ -1,5 +1,5 @@
 A :: blob {
-    a: int
+    a: int,
 }
 
 start :: fn {

--- a/progs/tests/faulty_list_index_assign.sy
+++ b/progs/tests/faulty_list_index_assign.sy
@@ -1,5 +1,5 @@
 Q :: blob {
-    a : [int]
+    a : [int],
 }
 
 start :: fn {

--- a/progs/tests/list_indexing.sy
+++ b/progs/tests/list_indexing.sy
@@ -1,5 +1,5 @@
 Q :: blob {
-    a : [int]
+    a : [int],
 }
 
 start :: fn {

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -109,6 +109,8 @@ enum Name {
 }
 
 #[derive(Debug)]
+/// Emulates the runtime stackframe.
+/// [variables] and [upvalues] are used like stacks.
 struct Frame {
     variables: Vec<Variable>,
     upvalues: Vec<Upvalue>,
@@ -428,13 +430,15 @@ impl Compiler {
         // Frame 0 has globals which cannot be captured.
         if frame == 0 { return Err(()) }
 
-        for var in self.frames[frame].variables.iter().rev() {
+        let variables = &self.frames[frame].variables;
+        for var in variables.iter().rev() {
             if &var.name == name && var.active {
                 return Ok(Lookup::Variable(var.clone()));
             }
         }
 
-        for up in self.frames[frame].upvalues.iter().rev() {
+        let upvalues = &self.frames[frame].upvalues;
+        for up in upvalues.iter().rev() {
             if &up.name == name {
                 return Ok(Lookup::Upvalue(up.clone()));
             }

--- a/sylt-parser/src/expression.rs
+++ b/sylt-parser/src/expression.rs
@@ -246,13 +246,15 @@ fn prefix<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
         T::Minus | T::Bang => unary(ctx),
 
         T::Identifier(_) => {
-
             let span = ctx.span();
             match (blob(ctx), assignable(ctx)) {
                 (Ok(result), _) => Ok(result),
                 (_, Ok((ctx, assign))) => Ok((
                     ctx,
-                    Expression { span, kind: Get(assign), },
+                    Expression {
+                        span,
+                        kind: Get(assign),
+                    },
                 )),
                 (Err((ctx, _)), Err(_)) => {
                     raise_syntax_error!(ctx, "Neither a blob instantiation or an identifier");
@@ -362,7 +364,6 @@ fn grouping_or_tuple<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
     let ctx = expect!(ctx, T::LeftParen, "Expected '('");
     let (mut ctx, skip_newlines) = ctx.push_skip_newlines(true);
 
-
     // The expressions contained in the parenthesis.
     let mut exprs = Vec::new();
 
@@ -430,7 +431,11 @@ fn blob<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
                 ctx = _ctx; // assign to outer
 
                 if !matches!(ctx.token(), T::Comma | T::RightBrace) {
-                    raise_syntax_error!(ctx, "Expected a field delimiter ',' - but got {:?}", ctx.token());
+                    raise_syntax_error!(
+                        ctx,
+                        "Expected a field delimiter ',' - but got {:?}",
+                        ctx.token()
+                    );
                 }
                 ctx = ctx.skip_if(T::Comma);
 

--- a/sylt-parser/src/expression.rs
+++ b/sylt-parser/src/expression.rs
@@ -425,7 +425,7 @@ fn blob<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
                 ctx = _ctx; // assign to outer
 
                 if !matches!(ctx.token(), T::Comma | T::RightBrace) {
-                    raise_syntax_error!(ctx, "Expected a delimiter: ','");
+                    raise_syntax_error!(ctx, "Expected a field delimiter ',' - but got {:?}", ctx.token());
                 }
                 ctx = ctx.skip_if(T::Comma);
 
@@ -631,7 +631,7 @@ mod test {
     test!(expression, call_arrow_grouping: "(1 + 0) -> a' 2, 3" => Get(_));
 
     test!(expression, instance: "A { a: 1 + 1, b: nil }" => Instance { .. });
-    test!(expression, instance_more: "A { a: 2\n c: 2 }" => Instance { .. });
+    test!(expression, instance_more: "A { a: 2, \n c: 2 }" => Instance { .. });
     test!(expression, instance_empty: "A {}" => Instance { .. });
 
     test!(expression, simple: "fn -> {}" => _);

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -805,6 +805,30 @@ mod test {
         };
     }
 
+    #[macro_export]
+    macro_rules! fail {
+        ($f:ident, $name:ident: $str:expr => $ans:pat) => {
+            #[test]
+            fn $name() {
+                let tokens = ::sylt_tokenizer::string_to_tokens($str);
+                let path = ::std::path::PathBuf::from(stringify!($name));
+                let result = $f($crate::Context::new(&tokens, &path));
+                assert!(
+                    result.is_err(),
+                    "\nSyntax tree test parsed - when it should have failed - for:\n{}\n",
+                    $str,
+                );
+                let (_, result) = result.unwrap_err();
+                assert!(
+                    matches!(result, $ans),
+                    "\nExpected: {}, but got: {:?}",
+                    stringify!($ans),
+                    result
+                );
+            }
+        };
+    }
+
     mod parse_type {
         use super::*;
         use RuntimeType as RT;

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -231,7 +231,8 @@ impl<'a> Context<'a> {
     fn push_skip_newlines(&self, skip_newlines: bool) -> (Self, bool) {
         let mut new = *self;
         new.skip_newlines = skip_newlines;
-        (new, self.skip_newlines)
+        // If currently on a newline token - we want to skip it.
+        (new.skip(0), self.skip_newlines)
     }
 
     /// Reset to old newline skipping state.

--- a/sylt-parser/src/statement.rs
+++ b/sylt-parser/src/statement.rs
@@ -134,15 +134,13 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
         [(T::Newline, _), ..] => (ctx.skip(1), EmptyStatement),
 
         // Block: `{ <statements> }`
-        [(T::LeftBrace, _), ..] => {
-            match (block_statement(ctx), expression(ctx)) {
-                (Ok((ctx, stmt)), _) => (ctx, stmt.kind),
-                (_, Ok((ctx, value))) => (ctx, StatementExpression { value }),
-                (Err((ctx, _)), Err(_)) => {
-                    raise_syntax_error!(ctx, "Neither a block nor a valid expression");
-                }
+        [(T::LeftBrace, _), ..] => match (block_statement(ctx), expression(ctx)) {
+            (Ok((ctx, stmt)), _) => (ctx, stmt.kind),
+            (_, Ok((ctx, value))) => (ctx, StatementExpression { value }),
+            (Err((ctx, _)), Err(_)) => {
+                raise_syntax_error!(ctx, "Neither a block nor a valid expression");
             }
-        }
+        },
 
         // `use a`
         [(T::Use, _), (T::Identifier(name), _), ..] => (
@@ -251,10 +249,7 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
                         fields.insert(field, ty);
 
                         if !matches!(ctx.token(), T::Comma | T::RightBrace) {
-                            raise_syntax_error!(
-                                ctx,
-                                "Expected a field deliminator ','"
-                            );
+                            raise_syntax_error!(ctx, "Expected a field deliminator ','");
                         }
                         ctx = ctx.skip_if(T::Comma);
                     }

--- a/sylt-parser/src/statement.rs
+++ b/sylt-parser/src/statement.rs
@@ -223,7 +223,9 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
         // Blob declaration: `A :: blob { <fields> }
         [(T::Identifier(name), _), (T::ColonColon, _), (T::Blob, _), ..] => {
             let name = name.clone();
-            let mut ctx = expect!(ctx.skip(3), T::LeftBrace, "Expected '{{' to open blob");
+            let ctx = expect!(ctx.skip(3), T::LeftBrace, "Expected '{{' to open blob");
+            let (mut ctx, skip_newlines) = ctx.push_skip_newlines(true);
+
             let mut fields = HashMap::new();
             // Parse fields: `a: int`
             loop {
@@ -260,6 +262,8 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
                     }
                 }
             }
+
+            let ctx = ctx.pop_skip_newlines(skip_newlines);
             let ctx = expect!(ctx, T::RightBrace, "Expected '}}' to close blob fields");
             (ctx, Blob { name, fields })
         }

--- a/sylt-parser/src/statement.rs
+++ b/sylt-parser/src/statement.rs
@@ -133,8 +133,13 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
 
         // Block: `{ <statements> }`
         [(T::LeftBrace, _), ..] => {
-            let (ctx, stmt) = block_statement(ctx)?;
-            (ctx, stmt.kind)
+            match (block_statement(ctx), expression(ctx)) {
+                (Ok((ctx, stmt)), _) => (ctx, stmt.kind),
+                (_, Ok((ctx, value))) => (ctx, StatementExpression { value }),
+                (Err((ctx, _)), Err(_)) => {
+                    raise_syntax_error!(ctx, "Neither a block nor a valid expression");
+                }
+            }
         }
 
         // `use a`

--- a/sylt-parser/src/statement.rs
+++ b/sylt-parser/src/statement.rs
@@ -431,7 +431,6 @@ mod test {
 
     // NOTE(ed): Expressions are valid statements! :D
     test!(statement, statement_expression: "1 + 1" => _);
-    test!(statement, statement_skip_newline: "(1 \n\n+\n 1\n\n)" => _);
     test!(statement, statement_print: "print 1" => _);
     test!(statement, statement_mut_declaration: "a := 1 + 1" => _);
     test!(statement, statement_const_declaration: "a :: 1 + 1" => _);
@@ -447,7 +446,6 @@ mod test {
     test!(statement, statement_unreach: "<!>" => _);
     test!(statement, statement_blob_empty: "A :: blob {}" => _);
     test!(statement, statement_blob_comma: "A :: blob { a: int, b: int }" => _);
-    test!(statement, statement_blob_newline: "A :: blob { a: int\n b: int }" => _);
     test!(statement, statement_blob_comma_newline: "A :: blob { a: int,\n b: int }" => _);
     test!(statement, statement_assign: "a = 1" => _);
     test!(statement, statement_assign_index: "a.b = 1 + 2" => _);
@@ -459,8 +457,17 @@ mod test {
     test!(statement, statement_assign_call_index: "a.c().c.b /= 4" => _);
     test!(statement, statement_idek: "a'.c'.c.b()().c = 0" => _);
 
+    test!(statement, statement_skip_newline: "(1 \n\n+\n 1\n\n)" => _);
+    test!(statement, statement_skip_newline_list: "[\n\n 1 \n\n,\n 1\n\n,]" => _);
+    test!(statement, statement_skip_newline_set: "{\n\n 1 \n\n,\n 1\n\n,}" => _);
+    test!(statement, statement_skip_newline_dict: "{\n\n 1: \n3\n,\n 1\n\n:1,}" => _);
+
     test!(outer_statement, outer_statement_blob: "B :: blob {}\n" => _);
+    test!(outer_statement, outer_statement_blob_no_last_comma: "B :: blob { \na: A\n }\n" => _);
+    test!(outer_statement, outer_statement_blob_yes_last_comma: "B :: blob { \na: A,\n }\n" => _);
     test!(outer_statement, outer_statement_declaration: "B :: fn -> {}\n" => _);
     test!(outer_statement, outer_statement_use: "use ABC\n" => _);
     test!(outer_statement, outer_statement_empty: "\n" => _);
+
+    fail!(statement, statement_blob_newline: "A :: blob { a: int\n b: int }" => _);
 }


### PR DESCRIPTION
Closes #193

Handle newlines in wierd places - though this change isn't trubble free.

There's a special case that I haven't thought of, consider:
```
A {
    a: 2,
    b: 3,
}
```
This could be either:
```
A        - Identifier
{ .. }   - A dict initlization
```
or
```
A { .. } - A blob initlization
```

Dosn't know which currently - but it makes me think I might have done goofed.
Are sets and dicts legal after any identifier? And how will this affect the `block expressions`?
