### PR TITLE
Cleaner syntax for type constants

### DIFF
--- a/progs/tests/is/simple.sy
+++ b/progs/tests/is/simple.sy
@@ -3,7 +3,10 @@ start :: fn {
     a := 2
     a is 2 <=> true
     a is a <=> true
-    a is #fn int -> int <=> false
-    a is #int <=> true
-    a is #float <=> false
+    a is :fn int -> int <=> false
+    a is :int <=> true
+    a is :float <=> false
+
+    b := :int | str
+    b is a
 }

--- a/sylt-parser/src/expression.rs
+++ b/sylt-parser/src/expression.rs
@@ -276,7 +276,7 @@ fn prefix<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
         T::LeftBracket => list(ctx),
         T::LeftBrace => set_or_dict(ctx),
 
-        T::Hash => {
+        T::Colon => {
             let span = ctx.span();
             let (ctx, ty) = parse_type(ctx.skip(1))?;
             Ok((
@@ -712,12 +712,12 @@ mod test {
 
     test!(expression, expr: "-a + b < 3 * true && false / 2" => _);
 
-    test!(expression, type_expr_int: "#int" => _);
-    test!(expression, type_expr_void: "#void" => _);
-    test!(expression, type_expr_float: "#float" => _);
-    test!(expression, type_expr_str: "#str" => _);
-    test!(expression, type_expr_custom: "#A" => _);
-    test!(expression, type_expr_custom_chaining: "#A.b.C" => _);
+    test!(expression, type_expr_int: ":int" => _);
+    test!(expression, type_expr_void: ":void" => _);
+    test!(expression, type_expr_float: ":float" => _);
+    test!(expression, type_expr_str: ":str" => _);
+    test!(expression, type_expr_custom: ":A" => _);
+    test!(expression, type_expr_custom_chaining: ":A.b.C" => _);
 
     test!(expression, void_simple: "fn {}" => _);
     test!(expression, void_argument: "fn a: int { ret a + 1 }" => _);


### PR DESCRIPTION
Type constants are now less different.

Instead of the old syntax:
```
#int | str
```
I changed the syntax to:
```
: int | str
```
This way - it motivates why the declaration-statements are the way they are:
```
a   : int | str = 3
b = : int | str
```

I feel pretty smart!
