### PR TITLE
Spans with column information in the parser and compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,17 +228,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
-name = "getrandom"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "gl"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,12 +519,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,46 +534,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -792,7 +735,7 @@ name = "sylt-common"
 version = "0.1.0"
 dependencies = [
  "owo-colors",
- "rand",
+ "sungod",
  "sylt-tokenizer",
  "sylt_macro",
 ]
@@ -922,12 +865,6 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gl"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +530,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +551,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -735,6 +792,7 @@ name = "sylt-common"
 version = "0.1.0"
 dependencies = [
  "owo-colors",
+ "rand",
  "sylt-tokenizer",
  "sylt_macro",
 ]
@@ -864,6 +922,12 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"

--- a/progs/tests/conflict_markers.sy
+++ b/progs/tests/conflict_markers.sy
@@ -8,4 +8,4 @@ start :: fn {
 
 }
 
-// error: Error::GitConflictError { start: 3, .. }
+// error: Error::GitConflictError { span: Span { line: 3 , .. }, .. }

--- a/progs/tests/conflict_markers_multiple.sy
+++ b/progs/tests/conflict_markers_multiple.sy
@@ -13,5 +13,5 @@ start :: fn {
 >>>>>>> 2
 }
 
-// error: Error::GitConflictError { start: 3, .. }
-// error: Error::GitConflictError { start: 9, .. }
+// error: Error::GitConflictError { span: Span { line: 3 , .. }, .. }
+// error: Error::GitConflictError { span: Span { line: 9 , .. }, .. }

--- a/progs/tests/conflict_markers_other_file.sy
+++ b/progs/tests/conflict_markers_other_file.sy
@@ -2,4 +2,4 @@ use conflict_markers
 
 start :: fn {}
 
-// error: Error::GitConflictError { start: 3, .. }
+// error: Error::GitConflictError { span: Span { line: 3 , .. }, .. }

--- a/sylt-common/Cargo.toml
+++ b/sylt-common/Cargo.toml
@@ -12,4 +12,5 @@ sylt_macro = { path = "../sylt_macro" }
 owo-colors = { git = "https://github.com/FredTheDino/owo-colors.git" }
 
 [dev-dependencies]
-rand = "0.8" # for generating random file names for tests
+# For generating random file names for tests
+sungod = { version = "0.3.1", features = ["default_is_random"] }

--- a/sylt-common/Cargo.toml
+++ b/sylt-common/Cargo.toml
@@ -10,3 +10,6 @@ sylt-tokenizer = { path = "../sylt-tokenizer" }
 sylt_macro = { path = "../sylt_macro" }
 
 owo-colors = { git = "https://github.com/FredTheDino/owo-colors.git" }
+
+[dev-dependencies]
+rand = "0.8" # for generating random file names for tests

--- a/sylt-common/src/error.rs
+++ b/sylt-common/src/error.rs
@@ -42,15 +42,11 @@ fn write_source_span_at(f: &mut fmt::Formatter<'_>, file: &Path, span: Span) -> 
     underline(f, span.col_start, span.col_end - span.col_start)
 }
 
-fn file_line_display(file: &Path, line: Option<usize>) -> String {
+fn file_line_display(file: &Path, line: usize) -> String {
     format!(
         "{}:{}",
         file.display().blue(),
-        if let Some(line) = line {
-            line.blue().to_string()
-        } else {
-            "??".blue().to_string()
-        }
+        line.blue().to_string(),
     )
 }
 
@@ -133,7 +129,7 @@ impl fmt::Display for Error {
             #[rustfmt::skip]
             Error::RuntimeError { kind, phase, file, line, message } => {
                 write!(f, "{} {}: ", phase.red(), "error".red())?;
-                write!(f, "{}\n", file_line_display(file, Some(*line)))?;
+                write!(f, "{}\n", file_line_display(file, *line))?;
                 write!(f, "{}{}\n", INDENT, kind)?;
 
                 if let Some(message) = message {
@@ -148,7 +144,7 @@ impl fmt::Display for Error {
                 message,
             } => {
                 write!(f, "{}: ", "compile error".red())?;
-                write!(f, "{}\n", file_line_display(file, Some(span.line)))?;
+                write!(f, "{}\n", file_line_display(file, span.line))?;
                 write!(f, "{}Failed to compile line {}\n", INDENT, span.line)?;
 
                 if let Some(message) = message {
@@ -163,7 +159,7 @@ impl fmt::Display for Error {
                 message,
             } => {
                 write!(f, "{}: ", "syntax error".red())?;
-                write!(f, "{}\n", file_line_display(file, Some(span.line)))?;
+                write!(f, "{}\n", file_line_display(file, span.line))?;
                 write!(f, "{}Syntax Error on line {}\n", INDENT, span.line)?;
 
                 if let Some(message) = message {
@@ -174,7 +170,7 @@ impl fmt::Display for Error {
             }
             Error::GitConflictError { file, span } => {
                 write!(f, "{}: ", "git conflict error".red())?;
-                write!(f, "{}\n", file_line_display(file, Some(span.line)))?;
+                write!(f, "{}\n", file_line_display(file, span.line))?;
 
                 write!(
                     f,

--- a/sylt-common/src/error.rs
+++ b/sylt-common/src/error.rs
@@ -327,48 +327,46 @@ mod test {
         tmp.clone()
     }
 
-    #[test]
-    fn write_source_span_simple() {
-        std::env::set_var("NO_COLOR", "1");
-        let p = write_str_to_tmp("hello\nstart :: fn {\n");
-        assert_eq!(
-            &format!(
-                "{}",
-                SourceSpanTester(
-                    &p,
-                    super::Span {
-                        line: 2,
-                        col_start: 1,
-                        col_end: 6,
-                    }
-                )
-            ),
-            "   1 | hello
-   2 | start :: fn {
-       ^^^^^\n",
-        );
+    macro_rules! test_source_span {
+        ($fn:ident, $src:expr, (line: $line:expr, col_start: $col_start:expr, col_end: $col_end:expr), $result:expr $(,)?) => {
+            #[test]
+            fn $fn() {
+                std::env::set_var("NO_COLOR", "1");
+                let path = write_str_to_tmp($src);
+                assert_eq!(
+                    &format!(
+                        "{}",
+                        SourceSpanTester(
+                            &path,
+                            super::Span {
+                                line: $line,
+                                col_start: $col_start,
+                                col_end: $col_end,
+                            }
+                        ),
+                    ),
+                    $result,
+                );
+            }
+        };
     }
 
-    #[test]
-    fn write_source_span_many_lines() {
-        std::env::set_var("NO_COLOR", "1");
-        let p = write_str_to_tmp("hello\nhello\nhello\nstart :: fn {\n  abc := 123\n  def := ghi\n}\n");
-        assert_eq!(
-            &format!(
-                "{}",
-                SourceSpanTester(
-                    &p,
-                    super::Span {
-                        line: 4,
-                        col_start: 1,
-                        col_end: 6,
-                    }
-                )
-            ),
-            "   2 | hello
+    test_source_span!(
+        write_source_span_display_simple,
+        "hello\nstart :: fn {\n",
+        (line: 2, col_start: 1, col_end: 6),
+        "   1 | hello
+   2 | start :: fn {
+       ^^^^^\n",
+    );
+
+    test_source_span!(
+        write_source_span_display_many_lines,
+        "hello\nhello\nhello\nstart :: fn {\n  abc := 123\n  def := ghi\n}\n",
+        (line: 4, col_start: 1, col_end: 6),
+        "   2 | hello
    3 | hello
    4 | start :: fn {
        ^^^^^\n",
-        );
-    }
+    );
 }

--- a/sylt-common/src/error.rs
+++ b/sylt-common/src/error.rs
@@ -313,9 +313,8 @@ mod test {
     }
 
     fn get_tmp() -> std::path::PathBuf {
-        use rand::Rng;
         let mut tmp = std::env::temp_dir();
-        tmp.push(format!("test-{}.sy", rand::thread_rng().gen::<u32>()));
+        tmp.push(format!("test-{}.sy", sungod::Ra::default().sample::<u32>()));
         tmp
     }
 

--- a/sylt-common/src/error.rs
+++ b/sylt-common/src/error.rs
@@ -96,6 +96,8 @@ pub enum Error {
     CompileError {
         file: PathBuf,
         line: usize,
+        col_start: usize,
+        col_end: usize,
         message: Option<String>,
     },
 
@@ -132,6 +134,8 @@ impl fmt::Display for Error {
             Error::CompileError {
                 file,
                 line,
+                col_start,
+                col_end,
                 message,
             } => {
                 write!(f, "{}: ", "compile error".red())?;
@@ -143,8 +147,20 @@ impl fmt::Display for Error {
                 }
                 write!(
                     f,
-                    "{}\n",
+                    "{}",
                     source_line_at(file, Some(*line)).unwrap_or_else(String::new)
+                )?;
+                write!(
+                    f,
+                    "{: <1$}",
+                    "",
+                    col_start + 6,
+                )?;
+                write!(
+                    f,
+                    "{:^<1$}\n",
+                    "",
+                    col_end - col_start,
                 )
             }
             Error::SyntaxError {

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -953,7 +953,7 @@ impl Compiler {
         let mut block = Block::new(name, 0, &tree.modules[0].0);
         block.ty = Type::Function(Vec::new(), Box::new(Type::Void));
         self.blocks.push(block);
-        self.frames.push(Frame::new(name, Span { line: 0 }));
+        self.frames.push(Frame::new(name, Span::zero()));
         let mut ctx = Context {
             block_slot: self.blocks.len() - 1,
             frame: self.frames.len() - 1,
@@ -975,8 +975,8 @@ impl Compiler {
         }
         let module = &tree.modules[0].1;
 
-        self.read_identifier("start", Span { line: 0 }, ctx, 0);
-        self.add_op(ctx, Span { line: 0 }, Op::Call(0));
+        self.read_identifier("start", Span::zero(), ctx, 0);
+        self.add_op(ctx, Span::zero(), Op::Call(0));
 
         let nil = self.constant(Value::Nil);
         self.add_op(ctx, module.span, nil);
@@ -1016,7 +1016,7 @@ impl Compiler {
                     error!(
                         self,
                         Context::from_namespace(slot),
-                        Span { line: 0 },
+                        Span::zero(),
                         "Reading module '{}' twice! How?",
                         full_path.display()
                     );
@@ -1120,7 +1120,7 @@ impl Compiler {
                         // Just fill in an empty slot since we have no idea.
                         // Unknown is overwritten by the Op::Force in the type checker.
                         let unknown = self.constant(Value::Unknown);
-                        self.add_op(ctx, Span { line: 0 }, unknown);
+                        self.add_op(ctx, Span::zero(), unknown);
 
                         let ty = self.resolve_type(ty, ctx);
                         let op = if let Op::Constant(ty) = self.constant(Value::Ty(ty)) {
@@ -1129,7 +1129,7 @@ impl Compiler {
                             error!(self, ctx, statement.span, "Failed to resolve the type");
                             Op::Illegal
                         };
-                        self.add_op(ctx, Span { line: 0 }, op);
+                        self.add_op(ctx, Span::zero(), op);
                     }
 
                     // Already handled in the loop before.

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -160,9 +160,7 @@ macro_rules! error {
             let msg = format!($( $msg ),*).into();
             let err = Error::CompileError {
                 file: $compiler.file_from_namespace($ctx.namespace).into(),
-                line: $span.line,
-                col_start: $span.col_start,
-                col_end: $span.col_end,
+                span: $span,
                 message: Some(msg),
             };
             $compiler.errors.push(err);
@@ -1098,7 +1096,7 @@ impl Compiler {
                                 error!(
                                     self,
                                     ctx,
-                                    span,
+                                    *span,
                                     "A global variable with the name '{}' already exists",
                                     name
                                 );

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -161,6 +161,8 @@ macro_rules! error {
             let err = Error::CompileError {
                 file: $compiler.file_from_namespace($ctx.namespace).into(),
                 line: $span.line,
+                col_start: $span.col_start,
+                col_end: $span.col_end,
                 message: Some(msg),
             };
             $compiler.errors.push(err);

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -15,6 +15,13 @@ pub use self::statement::{Statement, StatementKind};
 
 pub use sylt_tokenizer::Span;
 
+static INVALID_TOKEN: Token = Token::EOF;
+static INVALID_SPAN: Span = Span {
+    line: 0,
+    col_start_byte: 0,
+    col_end_byte: 0,
+};
+
 type T = Token;
 
 pub trait Next {
@@ -243,8 +250,8 @@ impl<'a> Context<'a> {
 
     /// Return the current [Token] and [Span].
     fn peek(&self) -> (&Token, &Span) {
-        let token = self.tokens.get(self.curr).unwrap_or(&T::EOF);
-        let span = self.spans.get(self.curr).unwrap_or(&Span { line: 0 });
+        let token = self.tokens.get(self.curr).unwrap_or(&INVALID_TOKEN);
+        let span = self.spans.get(self.curr).unwrap_or(&INVALID_SPAN);
         (token, span)
     }
 
@@ -651,7 +658,7 @@ fn module(path: &Path, token_stream: &[PlacedToken]) -> (Vec<PathBuf>, Result<Mo
         (
             use_files,
             Ok(Module {
-                span: Span { line: 0 },
+                span: Span::zero(),
                 statements,
             }),
         )

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use sylt_common::error::Error;
 use sylt_common::rc::Rc;
 use sylt_common::Type as RuntimeType;
-use sylt_tokenizer::{PlacedToken, Token, file_to_tokens};
+use sylt_tokenizer::{PlacedToken, Token, ZERO_SPAN, file_to_tokens};
 
 pub mod expression;
 pub mod statement;
@@ -15,14 +15,9 @@ pub use self::statement::{Statement, StatementKind};
 
 pub use sylt_tokenizer::Span;
 
-static INVALID_TOKEN: Token = Token::EOF;
-static INVALID_SPAN: Span = Span {
-    line: 0,
-    col_start: 0,
-    col_end: 0,
-};
-
 type T = Token;
+
+static EOF: Token = Token::EOF;
 
 pub trait Next {
     fn next(&self) -> Self;
@@ -257,8 +252,8 @@ impl<'a> Context<'a> {
 
     /// Return the current [Token] and [Span].
     fn peek(&self) -> (&Token, &Span) {
-        let token = self.tokens.get(self.curr).unwrap_or(&INVALID_TOKEN);
-        let span = self.spans.get(self.curr).unwrap_or(&INVALID_SPAN);
+        let token = self.tokens.get(self.curr).unwrap_or(&EOF);
+        let span = self.spans.get(self.curr).unwrap_or(&ZERO_SPAN);
         (token, span)
     }
 

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -189,6 +189,7 @@ type ParseResult<'t, T> = Result<(Context<'t>, T), (Context<'t>, Vec<Error>)>;
 pub struct Context<'a> {
     /// All tokens to be parsed.
     pub tokens: &'a [Token],
+    /// The corresponding span for each token. Matches 1:1 with the tokens.
     pub spans: &'a [Span],
     /// The index of the curren token in the token slice.
     pub curr: usize,

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -211,11 +211,6 @@ impl<'a> Context<'a> {
         *self.peek().1
     }
 
-    /// The line currently beeing parsed.
-    fn line(&self) -> usize {
-        self.span().line
-    }
-
     /// Move to the next nth token.
     fn skip(&self, n: usize) -> Self {
         let mut new = *self;
@@ -276,8 +271,7 @@ macro_rules! syntax_error {
             let msg = format!($( $msg ),*).into();
             Error::SyntaxError {
                 file: $ctx.file.to_path_buf(),
-                line: $ctx.line(),
-                token: $ctx.token().clone(),
+                span: $ctx.span(),
                 message: Some(msg),
             }
         }
@@ -696,7 +690,11 @@ pub fn find_conflict_markers(file: &Path) -> Vec<Error> {
         if line.starts_with("<<<<<<<") {
             errs.push(Error::GitConflictError {
                 file: file.to_path_buf(),
-                start: i + 1,
+                span: Span {
+                    line: i + 1,
+                    col_start: 0,
+                    col_end: "<<<<<<<".len(),
+                }
             });
         }
     }

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -6,12 +6,14 @@ use std::path::{Path, PathBuf};
 use sylt_common::error::Error;
 use sylt_common::rc::Rc;
 use sylt_common::Type as RuntimeType;
-use sylt_tokenizer::{file_to_tokens, Token};
+use sylt_tokenizer::{PlacedToken, Token, file_to_tokens};
 
 pub mod expression;
 pub mod statement;
 pub use self::expression::{Expression, ExpressionKind};
 pub use self::statement::{Statement, StatementKind};
+
+pub use sylt_tokenizer::Span;
 
 type T = Token;
 
@@ -21,15 +23,6 @@ pub trait Next {
 
 pub trait Numbered {
     fn to_number(&self) -> usize;
-}
-
-#[derive(Debug, Copy, Clone)]
-/// A location in a file containing source code.
-pub struct Span {
-    // TODO(ed): Do this more intelligent, so
-    // we can show ranges. Maybe even go back
-    // to offsets from start of the file.
-    pub line: usize,
 }
 
 /// Contains modules.
@@ -182,26 +175,25 @@ pub struct Type {
     pub kind: TypeKind,
 }
 
-/// Tokens and their line numbers.
-type Tokens = [(T, usize)];
-
 type ParseResult<'t, T> = Result<(Context<'t>, T), (Context<'t>, Vec<Error>)>;
 
 /// Keeps track of where the parser is currently parsing.
 #[derive(Debug, Copy, Clone)]
 pub struct Context<'a> {
     /// All tokens to be parsed.
-    pub tokens: &'a Tokens,
-    /// The index of the curren token in the tokens slice.
+    pub tokens: &'a [Token],
+    pub spans: &'a [Span],
+    /// The index of the curren token in the token slice.
     pub curr: usize,
     /// The file we're currently parsing.
     pub file: &'a Path,
 }
 
 impl<'a> Context<'a> {
-    fn new(tokens: &'a Tokens, file: &'a Path) -> Self {
+    fn new(tokens: &'a [Token], spans: &'a [Span], file: &'a Path) -> Self {
         Self {
             tokens,
+            spans,
             curr: 0,
             file,
         }
@@ -209,9 +201,7 @@ impl<'a> Context<'a> {
 
     /// Get a [Span] representing the current location of the parser.
     fn span(&self) -> Span {
-        Span {
-            line: self.peek().1,
-        }
+        *self.peek().1
     }
 
     /// The line currently beeing parsed.
@@ -251,9 +241,11 @@ impl<'a> Context<'a> {
         ret
     }
 
-    /// Return the current [Token] and line number.
-    fn peek(&self) -> &(T, usize) {
-        self.tokens.get(self.curr).unwrap_or(&(T::EOF, 0))
+    /// Return the current [Token] and [Span].
+    fn peek(&self) -> (&Token, &Span) {
+        let token = self.tokens.get(self.curr).unwrap_or(&T::EOF);
+        let span = self.spans.get(self.curr).unwrap_or(&Span { line: 0 });
+        (token, span)
     }
 
     /// Return the current [Token].
@@ -615,8 +607,10 @@ fn assignable<'t>(ctx: Context<'t>) -> ParseResult<'t, Assignable> {
 /// Returns any errors that occured when parsing the file. Basic error
 /// continuation is performed, so errored statements are skipped until a newline
 /// or EOF.
-fn module(path: &Path, tokens: &Tokens) -> (Vec<PathBuf>, Result<Module, Vec<Error>>) {
-    let mut ctx = Context::new(tokens, path);
+fn module(path: &Path, token_stream: &[PlacedToken]) -> (Vec<PathBuf>, Result<Module, Vec<Error>>) {
+    let tokens: Vec<_> = token_stream.iter().map(|p| p.token.clone()).collect();
+    let spans: Vec<_> = token_stream.iter().map(|p| p.span).collect();
+    let mut ctx = Context::new(&tokens, &spans, path);
     let mut errors = Vec::new();
     let mut use_files = Vec::new();
     let mut statements = Vec::new();
@@ -767,9 +761,11 @@ mod test {
         ($f:ident, $name:ident: $str:expr => $ans:pat) => {
             #[test]
             fn $name() {
-                let tokens = ::sylt_tokenizer::string_to_tokens($str);
+                let token_stream = ::sylt_tokenizer::string_to_tokens($str);
+                let tokens: Vec<_> = token_stream.iter().map(|p| p.token.clone()).collect();
+                let spans: Vec<_> = token_stream.iter().map(|p| p.span).collect();
                 let path = ::std::path::PathBuf::from(stringify!($name));
-                let result = $f($crate::Context::new(&tokens, &path));
+                let result = $f($crate::Context::new(&tokens, &spans, &path));
                 assert!(
                     result.is_ok(),
                     "\nSyntax tree test didn't parse for:\n{}\nErrs: {:?}",

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -17,8 +17,6 @@ pub use sylt_tokenizer::Span;
 
 type T = Token;
 
-static EOF: Token = Token::EOF;
-
 pub trait Next {
     fn next(&self) -> Self;
 }
@@ -252,7 +250,7 @@ impl<'a> Context<'a> {
 
     /// Return the current [Token] and [Span].
     fn peek(&self) -> (&Token, &Span) {
-        let token = self.tokens.get(self.curr).unwrap_or(&EOF);
+        let token = self.tokens.get(self.curr).unwrap_or(&T::EOF);
         let span = self.spans.get(self.curr).unwrap_or(&ZERO_SPAN);
         (token, span)
     }

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -18,8 +18,8 @@ pub use sylt_tokenizer::Span;
 static INVALID_TOKEN: Token = Token::EOF;
 static INVALID_SPAN: Span = Span {
     line: 0,
-    col_start_byte: 0,
-    col_end_byte: 0,
+    col_start: 0,
+    col_end: 0,
 };
 
 type T = Token;

--- a/sylt-parser/src/statement.rs
+++ b/sylt-parser/src/statement.rs
@@ -128,15 +128,15 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
 
     let span = ctx.span();
     let (ctx, kind) = match &ctx.tokens[ctx.curr..] {
-        [(T::Newline, _), ..] => (ctx.skip(1), EmptyStatement),
+        [T::Newline, ..] => (ctx.skip(1), EmptyStatement),
 
         // Block: `{ <statements> }`
-        [(T::LeftBrace, _), ..] => {
+        [T::LeftBrace, ..] => {
             return block_statement(ctx);
         }
 
         // `use a`
-        [(T::Use, _), (T::Identifier(name), _), ..] => (
+        [T::Use, T::Identifier(name), ..] => (
             ctx.skip(2),
             Use {
                 file: Identifier {
@@ -146,15 +146,15 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
             },
         ),
 
-        [(T::Unreachable, _), ..] => (ctx.skip(1), Unreachable),
+        [T::Unreachable, ..] => (ctx.skip(1), Unreachable),
 
-        [(T::Print, _), ..] => {
+        [T::Print, ..] => {
             let (ctx, value) = expression(ctx.skip(1))?;
             (ctx, Print { value })
         }
 
         // `ret <expression>`
-        [(T::Ret, _), ..] => {
+        [T::Ret, ..] => {
             let ctx = ctx.skip(1);
             let (ctx, value) = if matches!(ctx.token(), T::Newline) {
                 (
@@ -171,7 +171,7 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
         }
 
         // `loop <expression> <statement>`, e.g. `loop a < 10 { a += 1 }`
-        [(T::Loop, _), ..] => {
+        [T::Loop, ..] => {
             let (ctx, condition) = expression(ctx.skip(1))?;
             let (ctx, body) = statement(ctx)?;
             (
@@ -184,7 +184,7 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
         }
 
         // `if <expression> <statement> [else <statement>]`. Note that the else is optional.
-        [(T::If, _), ..] => {
+        [T::If, ..] => {
             let (ctx, condition) = expression(ctx.skip(1))?;
 
             let (ctx, pass) = statement(ctx)?;
@@ -214,7 +214,7 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
         }
 
         // Blob declaration: `A :: blob { <fields> }
-        [(T::Identifier(name), _), (T::ColonColon, _), (T::Blob, _), ..] => {
+        [T::Identifier(name), T::ColonColon, T::Blob, ..] => {
             let name = name.clone();
             let mut ctx = expect!(ctx.skip(3), T::LeftBrace, "Expected '{{' to open blob");
             let mut fields = HashMap::new();
@@ -258,7 +258,7 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
         }
 
         // Constant declaration, e.g. `a :: 1`.
-        [(T::Identifier(name), _), (T::ColonColon, _), ..] => {
+        [T::Identifier(name), T::ColonColon, ..] => {
             let ident = Identifier {
                 name: name.clone(),
                 span: ctx.span(),
@@ -284,7 +284,7 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
         }
 
         // Mutable declaration, e.g. `b := 2`.
-        [(T::Identifier(name), _), (T::ColonEqual, _), ..] => {
+        [T::Identifier(name), T::ColonEqual, ..] => {
             let ident = Identifier {
                 name: name.clone(),
                 span: ctx.span(),
@@ -310,7 +310,7 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
         }
 
         // Variable declaration with specified type, e.g. `c : int = 3` or `b : int | bool : false`.
-        [(T::Identifier(name), _), (T::Colon, _), ..] => {
+        [T::Identifier(name), T::Colon, ..] => {
             let ident = Identifier {
                 name: name.clone(),
                 span: ctx.span(),

--- a/sylt-tokenizer/src/tokenizer.rs
+++ b/sylt-tokenizer/src/tokenizer.rs
@@ -66,16 +66,11 @@ pub fn string_to_tokens(content: &str) -> Vec<PlacedToken> {
 
     Token::lexer(&content)
         .spanned()
+        // Contains side-effects.
         .map(|(token, byte_range)| {
             let is_newline = token == Token::Newline;
-            let col_start = char_at_byte[byte_range.start].expect(&format!(
-                "Token {:?} on line {} has invalid start byte offset {:?}",
-                token, line, byte_range
-            )) - last_newline;
-            let col_end = char_at_byte[byte_range.end].expect(&format!(
-                "Token {:?} on line {} has invalid end byte offset {:?}",
-                token, line, byte_range
-            )) - last_newline;
+            let col_start = char_at_byte[byte_range.start].unwrap() - last_newline;
+            let col_end = char_at_byte[byte_range.end].unwrap() - last_newline;
             let placed_token = PlacedToken {
                 token,
                 span: Span {
@@ -85,10 +80,7 @@ pub fn string_to_tokens(content: &str) -> Vec<PlacedToken> {
                 },
             };
             if is_newline {
-                last_newline = char_at_byte[byte_range.start].expect(&format!(
-                    "Newline token on line {} has invalid start byte offset {:?}",
-                    line, byte_range
-                ));
+                last_newline = char_at_byte[byte_range.start].unwrap();
                 line += 1;
             }
             placed_token

--- a/sylt-tokenizer/src/tokenizer.rs
+++ b/sylt-tokenizer/src/tokenizer.rs
@@ -17,6 +17,12 @@ pub struct Span {
     pub col_end: usize,
 }
 
+pub static ZERO_SPAN: Span = Span {
+    line: 0,
+    col_start: 0,
+    col_end: 0,
+};
+
 impl Span {
     pub fn zero() -> Self {
         Self {

--- a/sylt-tokenizer/src/tokenizer.rs
+++ b/sylt-tokenizer/src/tokenizer.rs
@@ -20,34 +20,21 @@ pub struct PlacedToken {
 }
 
 pub fn string_to_tokens(content: &str) -> Vec<PlacedToken> {
-    let lexer = Token::lexer(&content);
-
-    let mut placed_tokens = lexer.spanned().peekable();
-
-    let mut lined_tokens = Vec::new();
-    let mut line: usize = 1;
-    for (c_idx, c) in content.chars().enumerate() {
-        if let Some((token, t_range)) = placed_tokens.peek() {
-            if t_range.start == c_idx {
-                let token = token.clone();
-                placed_tokens.next();
-                lined_tokens.push(PlacedToken {
-                    token,
-                    span: Span {
-                        line,
-                    }
-                });
+    // Map with side-effects intended
+    let mut line = 1;
+    Token::lexer(&content)
+        .map(|token| {
+            if token == Token::Newline {
+                line += 1;
             }
-        } else {
-            break;
-        }
-
-        if c == '\n' {
-            line += 1;
-        }
-    }
-
-    lined_tokens
+            PlacedToken {
+                token,
+                span: Span {
+                    line,
+                }
+            }
+        })
+        .collect()
 }
 
 pub fn file_to_tokens(file: &Path) -> Result<Vec<PlacedToken>, std::io::Error> {

--- a/sylt-tokenizer/src/tokenizer.rs
+++ b/sylt-tokenizer/src/tokenizer.rs
@@ -68,7 +68,7 @@ pub fn string_to_tokens(content: &str) -> Vec<PlacedToken> {
                     line,
                     col_start: char_at_byte[range.start].unwrap() - last_newline,
                     col_end: char_at_byte[range.end].unwrap() - last_newline,
-                }
+                },
             };
             if is_newline {
                 line += 1;

--- a/sylt/src/lib.rs
+++ b/sylt/src/lib.rs
@@ -97,6 +97,8 @@ mod tests {
 
             #[allow(unused_imports)]
             use ::sylt_common::error::Error;
+            #[allow(unused_imports)]
+            use ::sylt_tokenizer::Span;
             if !matches!(errs.as_slice(), $expect) {
                 eprintln!("===== Got =====");
                 for err in errs {

--- a/sylt_macro/src/lib.rs
+++ b/sylt_macro/src/lib.rs
@@ -247,7 +247,7 @@ fn parse_test_settings(contents: String) -> TestSettings {
                 );
             }
             if line.starts_with("@") {
-                line = format!("Error::SyntaxError {{ line: {}, .. }}", &line[1..]);
+                line = format!("Error::SyntaxError {{ span: Span {{ line: {}, ..}}, .. }}", &line[1..]);
             }
             errors.push(line);
         } else if line.starts_with("// flags: ") {


### PR DESCRIPTION
Check it out!

```
// a.sy
start :: fn {
    // åäö <-- look ma, variable length encoding!
    abc := wow()
    a := 1
}
```
```
$ NO_COLOR=1 cargo run a.sy
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/sylt a.sy`
compile error: a.sy:3
      Failed to compile line 3
      Cannot read 'wow' in 'a.sy'
   1 | start :: fn {
   2 |     // åäö <-- look ma, variable length encoding!
   3 |     abc := wow()
                  ^^^

Error: "1 errors occured."
```

The compiler and type checker still only knows about lines though.