### PR TITLE
Is-statemnts

### DIFF
--- a/progs/tests/is/compile_time.sy
+++ b/progs/tests/is/compile_time.sy
@@ -1,0 +1,21 @@
+A :: blob {
+    a: int,
+}
+
+B :: blob {
+    a: int,
+    b: int,
+}
+
+C :: blob {
+    a: int,
+    b: int,
+    c: int,
+}
+
+:B is :B
+:A is :B
+:A is :C
+:B is :C
+
+start :: fn { }

--- a/progs/tests/is/compile_time_different.sy
+++ b/progs/tests/is/compile_time_different.sy
@@ -1,0 +1,19 @@
+A :: blob {
+    a: int,
+}
+
+B :: blob {
+    a: int,
+    b: str,
+}
+
+C :: blob {
+    a: int,
+    b: int,
+    c: str,
+}
+
+:A is :B
+:A is :C
+
+start :: fn { }

--- a/progs/tests/is/faulty_checking.sy
+++ b/progs/tests/is/faulty_checking.sy
@@ -24,5 +24,5 @@ C :: blob {
 
 start :: fn { }
 
-// error: Error::CompileError { .. } 
-// error: Error::CompileError { .. } 
+// error: Error::CompileError { .. }
+// error: Error::CompileError { .. }

--- a/progs/tests/is/faulty_checking.sy
+++ b/progs/tests/is/faulty_checking.sy
@@ -1,0 +1,28 @@
+A :: blob {
+    a: int,
+}
+
+B :: blob {
+    a: int,
+    b: str,
+}
+
+C :: blob {
+    a: int,
+    b: int,
+    c: str,
+}
+
+:A is :A
+:A is :B
+:A is :C
+:B is :B
+:C is :C
+
+:B is :A
+:C is :A
+
+start :: fn { }
+
+// error: Error::CompileError { .. } 
+// error: Error::CompileError { .. } 


### PR DESCRIPTION
Compiletime type constraints:

```
: A is : B
```

Fails with a compile time error if the type requirements are not met.

Great for making sure things are the way you want them to be.

I broke one thing here:
```
: A is a
```
And i'm unsure how to fix it. But this is parsed as a statement - which it isn't, it should be an is-expression. You can do this though:
```
(: A is a)
```


