### PR TITLE
0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ checksum = "b351cad1154eca506fab7bc868ffa732e641171a53d6e75aeaae0a042269c6f4"
 
 [[package]]
 name = "sylt"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "gumdrop",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "sylt-common"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "owo-colors",
  "serde",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "sylt-compiler"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "sylt-common",
  "sylt-parser",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "sylt-machine"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "owo-colors",
  "sylt-common",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "sylt-parser"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "sylt-common",
  "sylt-tokenizer",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "sylt-std"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "lazy_static",
@@ -961,14 +961,14 @@ dependencies = [
 
 [[package]]
 name = "sylt-tokenizer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "logos",
 ]
 
 [[package]]
 name = "sylt-typechecker"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "owo-colors",
  "sylt-common",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "sylt_macro"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "lazy_static",
  "proc-macro2",

--- a/sylt-common/Cargo.toml
+++ b/sylt-common/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "sylt-common"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sylt-tokenizer = { version = "0.1.0", path = "../sylt-tokenizer" }
-sylt_macro = { version = "0.1.0", path = "../sylt_macro" }
+sylt-tokenizer = { version = "0.2.0", path = "../sylt-tokenizer" }
+sylt_macro = { version = "0.2.0", path = "../sylt_macro" }
 
 owo-colors = { git = "https://github.com/FredTheDino/owo-colors.git" }
 serde = { version = "1", features = ["derive", "rc"] }

--- a/sylt-common/Cargo.toml
+++ b/sylt-common/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sylt-tokenizer = { path = "../sylt-tokenizer" }
-sylt_macro = { path = "../sylt_macro" }
+sylt-tokenizer = { version = "0.1.0", path = "../sylt-tokenizer" }
+sylt_macro = { version = "0.1.0", path = "../sylt_macro" }
 
 owo-colors = { git = "https://github.com/FredTheDino/owo-colors.git" }
 serde = { version = "1", features = ["derive", "rc"] }

--- a/sylt-compiler/Cargo.toml
+++ b/sylt-compiler/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 path = "src/compiler.rs"
 
 [dependencies]
-sylt-common = { path = "../sylt-common" }
-sylt-parser = { path = "../sylt-parser" }
+sylt-common = { version = "0.1.0", path = "../sylt-common" }
+sylt-parser = { version = "0.1.0", path = "../sylt-parser" }

--- a/sylt-compiler/Cargo.toml
+++ b/sylt-compiler/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "sylt-compiler"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 [lib]
 path = "src/compiler.rs"
 
 [dependencies]
-sylt-common = { version = "0.1.0", path = "../sylt-common" }
-sylt-parser = { version = "0.1.0", path = "../sylt-parser" }
+sylt-common = { version = "0.2.0", path = "../sylt-common" }
+sylt-parser = { version = "0.2.0", path = "../sylt-parser" }

--- a/sylt-machine/Cargo.toml
+++ b/sylt-machine/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 path = "src/vm.rs"
 
 [dependencies]
-sylt-common = { path = "../sylt-common" }
+sylt-common = { version = "0.1.0", path = "../sylt-common" }
 
 owo-colors = { git = "https://github.com/FredTheDino/owo-colors.git" }

--- a/sylt-machine/Cargo.toml
+++ b/sylt-machine/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "sylt-machine"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 [lib]
 path = "src/vm.rs"
 
 [dependencies]
-sylt-common = { version = "0.1.0", path = "../sylt-common" }
+sylt-common = { version = "0.2.0", path = "../sylt-common" }
 
 owo-colors = { git = "https://github.com/FredTheDino/owo-colors.git" }

--- a/sylt-parser/Cargo.toml
+++ b/sylt-parser/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "sylt-parser"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 [lib]
 path = "src/parser.rs"
 
 [dependencies]
-sylt-common = { version = "0.1.0", path = "../sylt-common" }
-sylt-tokenizer = { version = "0.1.0", path = "../sylt-tokenizer" }
-sylt_macro = { version = "0.1.0", path = "../sylt_macro" }
+sylt-common = { version = "0.2.0", path = "../sylt-common" }
+sylt-tokenizer = { version = "0.2.0", path = "../sylt-tokenizer" }
+sylt_macro = { version = "0.2.0", path = "../sylt_macro" }

--- a/sylt-parser/Cargo.toml
+++ b/sylt-parser/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 path = "src/parser.rs"
 
 [dependencies]
-sylt-common = { path = "../sylt-common" }
-sylt-tokenizer = { path = "../sylt-tokenizer" }
-sylt_macro = { path = "../sylt_macro" }
-
+sylt-common = { version = "0.1.0", path = "../sylt-common" }
+sylt-tokenizer = { version = "0.1.0", path = "../sylt-tokenizer" }
+sylt_macro = { version = "0.1.0", path = "../sylt_macro" }

--- a/sylt-std/Cargo.toml
+++ b/sylt-std/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "sylt-std"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sylt-common = { version = "0.1.0", path = "../sylt-common" }
-sylt_macro = { version = "0.1.0", path = "../sylt_macro" }
+sylt-common = { version = "0.2.0", path = "../sylt-common" }
+sylt_macro = { version = "0.2.0", path = "../sylt_macro" }
 
 bincode = { version = "1", optional = true }
 lazy_static = "1"

--- a/sylt-std/Cargo.toml
+++ b/sylt-std/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sylt-common = { path = "../sylt-common" }
-sylt_macro = { path = "../sylt_macro" }
+sylt-common = { version = "0.1.0", path = "../sylt-common" }
+sylt_macro = { version = "0.1.0", path = "../sylt_macro" }
 
 bincode = { version = "1", optional = true }
 lazy_static = "1"

--- a/sylt-tokenizer/Cargo.toml
+++ b/sylt-tokenizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylt-tokenizer"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 [lib]

--- a/sylt-tokenizer/Cargo.toml
+++ b/sylt-tokenizer/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2018"
 path = "src/tokenizer.rs"
 
 [dependencies]
-
 logos = "0.12"

--- a/sylt-typechecker/Cargo.toml
+++ b/sylt-typechecker/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "sylt-typechecker"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 [lib]
 path = "src/typechecker.rs"
 
 [dependencies]
-sylt-common = { version = "0.1.0", path = "../sylt-common" }
+sylt-common = { version = "0.2.0", path = "../sylt-common" }
 
 owo-colors = { git = "https://github.com/FredTheDino/owo-colors.git" }

--- a/sylt-typechecker/Cargo.toml
+++ b/sylt-typechecker/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 path = "src/typechecker.rs"
 
 [dependencies]
-sylt-common = { path = "../sylt-common" }
+sylt-common = { version = "0.1.0", path = "../sylt-common" }
 
 owo-colors = { git = "https://github.com/FredTheDino/owo-colors.git" }

--- a/sylt/Cargo.toml
+++ b/sylt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylt"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Edvard Thörnros <edvard.thornros@gmail.com>", "Gustav Sörnäs <gustav@sornas.net>"]
 edition = "2018"
 default-run = "sylt"
@@ -11,13 +11,13 @@ name = "sylt"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sylt-common = { version = "0.1.0", path = "../sylt-common" }
-sylt-compiler = { version = "0.1.0", path = "../sylt-compiler" }
-sylt-machine = { version = "0.1.0", path = "../sylt-machine" }
-sylt-parser = { version = "0.1.0", path = "../sylt-parser" }
-sylt-std = { version = "0.1.0", path = "../sylt-std", default-features = false }
-sylt-tokenizer = { version = "0.1.0", path = "../sylt-tokenizer" }
-sylt-typechecker = { version = "0.1.0", path = "../sylt-typechecker" }
+sylt-common = { version = "0.2.0", path = "../sylt-common" }
+sylt-compiler = { version = "0.2.0", path = "../sylt-compiler" }
+sylt-machine = { version = "0.2.0", path = "../sylt-machine" }
+sylt-parser = { version = "0.2.0", path = "../sylt-parser" }
+sylt-std = { version = "0.2.0", path = "../sylt-std", default-features = false }
+sylt-tokenizer = { version = "0.2.0", path = "../sylt-tokenizer" }
+sylt-typechecker = { version = "0.2.0", path = "../sylt-typechecker" }
 
 owo-colors = { git = "https://github.com/FredTheDino/owo-colors.git" }
 sylt_macro = { path = "../sylt_macro" }

--- a/sylt/Cargo.toml
+++ b/sylt/Cargo.toml
@@ -11,13 +11,13 @@ name = "sylt"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sylt-common = { path = "../sylt-common" }
-sylt-compiler = { path = "../sylt-compiler" }
-sylt-machine = { path = "../sylt-machine" }
-sylt-parser = { path = "../sylt-parser" }
-sylt-std = { path = "../sylt-std", default-features = false }
-sylt-tokenizer = { path = "../sylt-tokenizer" }
-sylt-typechecker = { path = "../sylt-typechecker" }
+sylt-common = { version = "0.1.0", path = "../sylt-common" }
+sylt-compiler = { version = "0.1.0", path = "../sylt-compiler" }
+sylt-machine = { version = "0.1.0", path = "../sylt-machine" }
+sylt-parser = { version = "0.1.0", path = "../sylt-parser" }
+sylt-std = { version = "0.1.0", path = "../sylt-std", default-features = false }
+sylt-tokenizer = { version = "0.1.0", path = "../sylt-tokenizer" }
+sylt-typechecker = { version = "0.1.0", path = "../sylt-typechecker" }
 
 owo-colors = { git = "https://github.com/FredTheDino/owo-colors.git" }
 sylt_macro = { path = "../sylt_macro" }

--- a/sylt_macro/Cargo.toml
+++ b/sylt_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylt_macro"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Edvard Thörnros <edvard.thornros@gmail.com", "Gustav Sörnäs <gustav@sornas.net>"]
 edition = "2018"
 


### PR DESCRIPTION
Now that #311 is merged we can think about tagging a release. This PR does two things that help with this.
1) Add a "version = 0.1.0" to all internal dependencies. This is needed in case we want to publish to crates.io and this felt like the right time. This also makes it a prime candidate for a 0.1.0-tag.
2) Bump to 0.2.0. We don't really care about semver technicalities just yet (imo) since it's easier to move all versions at the same time.