### PR TITLE
Detailing of error messages

### DIFF
--- a/sylt-common/src/error.rs
+++ b/sylt-common/src/error.rs
@@ -104,7 +104,7 @@ pub enum Error {
     SyntaxError {
         file: PathBuf,
         span: Span,
-        message: Option<String>,
+        message: String,
     },
 
     CompileError {
@@ -162,9 +162,7 @@ impl fmt::Display for Error {
                 write!(f, "{}\n", file_line_display(file, span.line))?;
                 write!(f, "{}Syntax Error on line {}\n", INDENT, span.line)?;
 
-                if let Some(message) = message {
-                    write!(f, "{}{}\n", INDENT, message)?;
-                }
+                write!(f, "{}{}\n", INDENT, message)?;
 
                 write_source_span_at(f, file, *span)
             }

--- a/sylt-parser/src/expression.rs
+++ b/sylt-parser/src/expression.rs
@@ -735,7 +735,7 @@ fn set_or_dict<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
             // Something that's part of an inner expression.
             _ => {
                 // Parse the expression.
-                let (_ctx, expr) = expression(ctx)?;
+                let (_ctx, expr) = detail_error!(expression(ctx), "failed to parse dict or set")?;
                 ctx = _ctx; // assign to outer
                 exprs.push(expr);
 

--- a/sylt-parser/src/expression.rs
+++ b/sylt-parser/src/expression.rs
@@ -735,7 +735,7 @@ fn set_or_dict<'t>(ctx: Context<'t>) -> ParseResult<'t, Expression> {
             // Something that's part of an inner expression.
             _ => {
                 // Parse the expression.
-                let (_ctx, expr) = detail_error!(expression(ctx), "failed to parse dict or set")?;
+                let (_ctx, expr) = detail_if_error!(expression(ctx), "failed to parse dict or set")?;
                 ctx = _ctx; // assign to outer
                 exprs.push(expr);
 

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -292,7 +292,7 @@ macro_rules! detail_error {
                             },
 
                         x =>
-                            unreachable!("Can only detail SyntaxError - but got {:?}", x),
+                            unreachable!("Can only detail SyntaxError but got {:?}", x),
 
                     };
                     errs.insert(0, err);

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -271,7 +271,7 @@ impl<'a> Context<'a> {
 
 /// Add more text to an error message after it has been created.
 #[macro_export]
-macro_rules! detail_error {
+macro_rules! detail_if_error {
     ($res:expr, $( $msg:expr ),* ) => {
         {
             match $res {


### PR DESCRIPTION
Throughout our parsing codebase we generate errors - but some could benefit from knowing the context they are in which might not be known when the error is first created. This PR adds a macro to add information to syntax errors after they've been created.

Closes #296