### PR TITLE
Fix breaks and continues in loops - but break the typechecker

### DIFF
--- a/progs/tests/looping/break_and_declare.sy
+++ b/progs/tests/looping/break_and_declare.sy
@@ -1,0 +1,12 @@
+start :: fn {
+    s := ""
+    loop true {
+        next := s + "a"
+        s = next
+        if s == "aaa" {
+            break
+        }
+        next := s + "a"
+    }
+    s <=> "aaa"
+}

--- a/progs/tests/looping/continue_and_declare.sy
+++ b/progs/tests/looping/continue_and_declare.sy
@@ -1,0 +1,13 @@
+start :: fn {
+    s := ""
+    i := 0
+    loop i < 3 {
+        next := s + "a"
+        i += 1
+        if i > 2 {
+            continue
+        }
+        s = next
+    }
+    s <=> "aa"
+}

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -276,7 +276,7 @@ impl Compiler {
 
     fn emit_pop_until_size(&mut self, ctx: Context, span: Span, target_size: usize) {
         let vars: Vec<_> = self.frames[ctx.frame].variables.iter().skip(target_size).rev().cloned().collect();
-        for var in vars.iter() {
+        for var in &vars {
             if var.captured {
                 self.add_op(ctx, span, Op::PopUpvalue);
             } else {

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -274,15 +274,20 @@ impl Compiler {
             .curr()
     }
 
-    fn pop_until_size(&mut self, ctx: Context, span: Span, target_size: usize) {
-        while target_size < self.frames[ctx.frame].variables.len() {
-            let var = self.frames[ctx.frame].variables.pop().unwrap();
+    fn emit_pop_until_size(&mut self, ctx: Context, span: Span, target_size: usize) {
+        let vars: Vec<_> = self.frames[ctx.frame].variables.iter().skip(target_size).rev().cloned().collect();
+        for var in vars.iter() {
             if var.captured {
                 self.add_op(ctx, span, Op::PopUpvalue);
             } else {
                 self.add_op(ctx, span, Op::Pop);
             }
         }
+    }
+
+    fn pop_until_size(&mut self, ctx: Context, span: Span, target_size: usize) {
+        self.emit_pop_until_size(ctx, span, target_size);
+        self.frames[ctx.frame].variables.truncate(target_size);
     }
 
     fn assignable(&mut self, ass: &Assignable, ctx: Context) -> Option<usize> {
@@ -1019,7 +1024,7 @@ impl Compiler {
 
             Continue {} => match self.loops.last().cloned() {
                 Some(LoopFrame { stack_size, continue_addr, .. }) => {
-                    self.pop_until_size(ctx, statement.span, stack_size);
+                    self.emit_pop_until_size(ctx, statement.span, stack_size);
                     self.add_op(ctx, statement.span, Op::Jmp(continue_addr));
                 }
                 None => {
@@ -1029,7 +1034,7 @@ impl Compiler {
 
             Break {} => match self.loops.last().cloned() {
                 Some(LoopFrame { stack_size, break_addr, .. }) => {
-                    self.pop_until_size(ctx, statement.span, stack_size);
+                    self.emit_pop_until_size(ctx, statement.span, stack_size);
                     self.add_op(ctx, statement.span, Op::Jmp(break_addr));
                 }
                 None => {

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -1024,6 +1024,17 @@ impl Compiler {
 
             Continue {} => match self.loops.last().cloned() {
                 Some(LoopFrame { stack_size, continue_addr, .. }) => {
+                    // TODO(ed): Remove this crutch when the typechecker is fixed.
+                    // We emit dummy values that are popped in the typechecker.
+                    let type_checker_skip = self.add_op(ctx, statement.span, Op::Illegal);
+                    let current_stack_size = self.frames[ctx.frame].variables.len();
+                    let nil = self.constant(Value::Nil);
+                    for _ in 0..(current_stack_size - stack_size) {
+                        self.add_op(ctx, statement.span, nil);
+                    }
+                    let end = self.next_ip(ctx);
+                    self.patch(ctx, type_checker_skip, Op::Jmp(end));
+
                     self.emit_pop_until_size(ctx, statement.span, stack_size);
                     self.add_op(ctx, statement.span, Op::Jmp(continue_addr));
                 }
@@ -1034,6 +1045,17 @@ impl Compiler {
 
             Break {} => match self.loops.last().cloned() {
                 Some(LoopFrame { stack_size, break_addr, .. }) => {
+                    // TODO(ed): Remove this crutch when the typechecker is fixed.
+                    // We emit dummy values that are popped in the typechecker.
+                    let type_checker_skip = self.add_op(ctx, statement.span, Op::Illegal);
+                    let current_stack_size = self.frames[ctx.frame].variables.len();
+                    let nil = self.constant(Value::Nil);
+                    for _ in 0..(current_stack_size - stack_size) {
+                        self.add_op(ctx, statement.span, nil);
+                    }
+                    let end = self.next_ip(ctx);
+                    self.patch(ctx, type_checker_skip, Op::Jmp(end));
+
                     self.emit_pop_until_size(ctx, statement.span, stack_size);
                     self.add_op(ctx, statement.span, Op::Jmp(break_addr));
                 }


### PR DESCRIPTION
- Fix breaks and continues in loops - but brake the typechecker
- Add workaround for break and continue
- Add tests for declaring variables in loops

Solves #298
