### PR TITLE
Fix assert precedence

### DIFF
--- a/sylt-parser/src/expression.rs
+++ b/sylt-parser/src/expression.rs
@@ -235,7 +235,7 @@ fn precedence(token: &T) -> Prec {
     use Prec;
 
     match token {
-        T::LeftBracket => Prec::Index,
+        T::LeftBracket | T::Dot | T::LeftParen => Prec::Index,
 
         T::Star | T::Slash => Prec::Factor,
 

--- a/tests/bugs/assert_precedence_355.sy
+++ b/tests/bugs/assert_precedence_355.sy
@@ -1,0 +1,8 @@
+A :: blob {
+    a: int
+}
+
+start :: fn {
+    2 <=> fn -> int { 2 }()
+    A { a: 1 }.a <=> A { a: 1 }.a
+}


### PR DESCRIPTION
Turns out, it was not the assert precedence that was wrong. It was
accesses with the dot and call operators that simply did not have a
precedence.

Closes #355 