### PR TITLE
Disable doc tests for all modules

### DIFF
--- a/sylt-common/Cargo.toml
+++ b/sylt-common/Cargo.toml
@@ -21,3 +21,6 @@ serde = { version = "1", features = ["derive", "rc"] }
 [dev-dependencies]
 # For generating random file names for tests
 sungod = { version = "0.3.1", features = ["default_is_random"] }
+
+[lib]
+doctest = false

--- a/sylt-compiler/Cargo.toml
+++ b/sylt-compiler/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [lib]
 path = "src/compiler.rs"
+doctest = false
 
 [dependencies]
 sylt-common = { version = "0.2.0", path = "../sylt-common" }

--- a/sylt-machine/Cargo.toml
+++ b/sylt-machine/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [lib]
 path = "src/vm.rs"
+doctest = false
 
 [dependencies]
 sylt-common = { version = "0.2.0", path = "../sylt-common" }

--- a/sylt-macro/Cargo.toml
+++ b/sylt-macro/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 syn = { version = "1", features = ["full"] }

--- a/sylt-parser/Cargo.toml
+++ b/sylt-parser/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [lib]
 path = "src/parser.rs"
+doctest = false
 
 [dependencies]
 sylt-common = { version = "0.2.0", path = "../sylt-common" }

--- a/sylt-std/Cargo.toml
+++ b/sylt-std/Cargo.toml
@@ -25,3 +25,6 @@ sungod = "0.3"
 default = [ "lingon", "network" ]
 
 network = ["bincode"]
+
+[lib]
+doctest = false

--- a/sylt-tokenizer/Cargo.toml
+++ b/sylt-tokenizer/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [lib]
 path = "src/tokenizer.rs"
+doctest = false
 
 [dependencies]
 logos = "0.12"

--- a/sylt-typechecker/Cargo.toml
+++ b/sylt-typechecker/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [lib]
 path = "src/typechecker.rs"
+doctest = false
 
 [dependencies]
 sylt-common = { version = "0.2.0", path = "../sylt-common" }

--- a/sylt/Cargo.toml
+++ b/sylt/Cargo.toml
@@ -12,6 +12,7 @@ default-run = "sylt"
 
 [lib]
 name = "sylt"
+doctest = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
They were not used and was taking up too much output space. Should we also turn off the unit tests that don't have tests in them right now?