### PR TITLE
Simplify types

### DIFF
--- a/sylt-parser/src/expression.rs
+++ b/sylt-parser/src/expression.rs
@@ -4,7 +4,7 @@ use crate::statement::block;
 
 use super::*;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ComparisonKind {
     Equals,
     NotEquals,
@@ -19,7 +19,7 @@ pub enum ComparisonKind {
 /// The different kinds of [Expression]s.
 ///
 /// Expressions are recursive and evaluate to some kind of value.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ExpressionKind {
     /// Read from an [Assignable]. Variables, function calls, module accesses,
     /// blob fields, list indexing, tuple indexing and dict indexing end up here.
@@ -105,6 +105,12 @@ pub enum ExpressionKind {
 pub struct Expression {
     pub span: Span,
     pub kind: ExpressionKind,
+}
+
+impl PartialEq for Expression {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+    }
 }
 
 /// Parse an [ExpressionKind::Function]: `fn a: int, b: bool -> bool <statement>`

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -63,7 +63,7 @@ pub enum Prec {
 ///
 /// Forced variable kinds are a signal to the type checker that the type is
 /// assumed and shouldn't be checked.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum VarKind {
     Const,
     Mutable,
@@ -82,7 +82,7 @@ impl VarKind {
 }
 
 /// The different kinds of assignment operators: `+=`, `-=`, `*=`, `/=` and `=`.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Op {
     Nop,
     Add,
@@ -95,6 +95,12 @@ pub enum Op {
 pub struct Identifier {
     pub span: Span,
     pub name: String,
+}
+
+impl PartialEq for Identifier {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
 }
 
 /// The different kinds of [Assignable]s.
@@ -119,7 +125,7 @@ pub struct Identifier {
 ///     )
 /// )
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum AssignableKind {
     Read(Identifier),
     /// A function call.
@@ -148,7 +154,13 @@ pub struct Assignable {
     pub kind: AssignableKind,
 }
 
-#[derive(Debug, Clone)]
+impl PartialEq for Assignable {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum TypeKind {
     /// An unspecified type that is left to the type checker.
     Implied,
@@ -177,6 +189,12 @@ pub enum TypeKind {
 pub struct Type {
     pub span: Span,
     pub kind: TypeKind,
+}
+
+impl PartialEq for Type {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+    }
 }
 
 type ParseResult<'t, T> = Result<(Context<'t>, T), (Context<'t>, Vec<Error>)>;

--- a/sylt-parser/src/statement.rs
+++ b/sylt-parser/src/statement.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// The different ways a namespace is introduced by a use statement.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum NameIdentifier {
     /// When the identifier is implicit from the path. For example, `use a/b` introduces `b`.
     Implicit(Identifier),
@@ -16,7 +16,7 @@ pub enum NameIdentifier {
 /// examples of how they look in the code.
 ///
 /// Note that this shouldn't be read as a formal language specification.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum StatementKind {
     /// "Imports" another file.
     ///
@@ -129,6 +129,12 @@ pub struct Statement {
     pub span: Span,
     pub kind: StatementKind,
     pub comments: Vec<String>,
+}
+
+impl PartialEq for Statement {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+    }
 }
 
 pub fn path<'t>(ctx: Context<'t>) -> ParseResult<'t, Identifier> {

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -91,7 +91,6 @@ fn simplify_type(ty: Type) -> Type {
     match ty.kind {
         TK::Union(_, _) => {
             let without_dupes = remove_duplicates(ty.clone(), Vec::new());
-            dbg!(&without_dupes);
             without_dupes.into_iter().reduce(|a, b| {
                 // Swap order so we nest to the right
                 Type { kind: TK::Union(Box::new(b), Box::new(a)), span: ty.span }

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -68,7 +68,56 @@ fn write_blob_fields<W: Write>(
     Ok(())
 }
 
+
+fn simplify_type(ty: Type) -> Type {
+    fn remove_duplicates(ty: Type, mut seen: Vec<Type>) -> Vec<Type> {
+        match ty.kind {
+            TK::Union(ty, rest) => {
+                if seen.iter().find(|a| **a == *ty).is_none() {
+                    seen.push(*ty);
+                }
+                remove_duplicates(*rest, seen)
+            }
+            _ => {
+                if seen.iter().find(|a| **a == ty).is_none() {
+                    seen.push(ty);
+                }
+                seen
+            }
+        }
+    }
+
+    use TypeKind as TK;
+    match ty.kind {
+        TK::Union(_, _) => {
+            let without_dupes = remove_duplicates(ty.clone(), Vec::new());
+            dbg!(&without_dupes);
+            without_dupes.into_iter().reduce(|a, b| {
+                // Swap order so we nest to the right
+                Type { kind: TK::Union(Box::new(b), Box::new(a)), span: ty.span }
+            }).unwrap() // We always get one type
+        }
+
+        TK::Fn(args, ret) =>
+            Type { kind: TK::Fn(args.into_iter().map(simplify_type).collect(), Box::new(simplify_type(*ret))), ..ty },
+        TK::Tuple(tys) =>
+            Type { kind: TK::Tuple(tys.into_iter().map(simplify_type).collect()), ..ty },
+        TK::List(a) =>
+            Type { kind: TK::List(Box::new(simplify_type(*a))), ..ty },
+        TK::Set(a) =>
+            Type { kind: TK::Set(Box::new(simplify_type(*a))), ..ty },
+        TK::Dict(a, b) =>
+            Type { kind: TK::Dict(Box::new(simplify_type(*a)), Box::new(simplify_type(*b))), ..ty },
+
+        TK::Implied
+        | TK::UserDefined(_)
+        | TK::Resolved(_)
+        | TK::Generic(_) => ty,
+    }
+}
+
 fn write_type<W: Write>(dest: &mut W, indent: u32, ty: Type) -> fmt::Result {
+    let ty = simplify_type(ty);
     match ty.kind {
         TypeKind::Implied => unreachable!(),
         TypeKind::Resolved(ty) => write!(dest, "{}", ty),

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -68,11 +68,10 @@ fn write_blob_fields<W: Write>(
     Ok(())
 }
 
-
 fn simplify_type(ty: Type) -> Type {
     fn remove_duplicates(ty: Type, mut seen: Vec<Type>) -> Vec<Type> {
         match ty.kind {
-            TK::Union(ty, rest) => {
+            TypeKind::Union(ty, rest) => {
                 if seen.iter().find(|a| **a == *ty).is_none() {
                     seen.push(*ty);
                 }
@@ -87,30 +86,29 @@ fn simplify_type(ty: Type) -> Type {
         }
     }
 
-    use TypeKind as TK;
     match ty.kind {
-        TK::Union(_, _) => {
+        TypeKind::Union(_, _) => {
             let without_dupes = remove_duplicates(ty.clone(), Vec::new());
             without_dupes.into_iter().reduce(|a, b| {
-                Type { kind: TK::Union(Box::new(a), Box::new(b)), span: ty.span }
+                Type { kind: TypeKind::Union(Box::new(a), Box::new(b)), span: ty.span }
             }).unwrap() // We always get one type
         }
 
-        TK::Fn(args, ret) =>
-            Type { kind: TK::Fn(args.into_iter().map(simplify_type).collect(), Box::new(simplify_type(*ret))), ..ty },
-        TK::Tuple(tys) =>
-            Type { kind: TK::Tuple(tys.into_iter().map(simplify_type).collect()), ..ty },
-        TK::List(a) =>
-            Type { kind: TK::List(Box::new(simplify_type(*a))), ..ty },
-        TK::Set(a) =>
-            Type { kind: TK::Set(Box::new(simplify_type(*a))), ..ty },
-        TK::Dict(a, b) =>
-            Type { kind: TK::Dict(Box::new(simplify_type(*a)), Box::new(simplify_type(*b))), ..ty },
+        TypeKind::Fn(args, ret) =>
+            Type { kind: TypeKind::Fn(args.into_iter().map(simplify_type).collect(), Box::new(simplify_type(*ret))), ..ty },
+        TypeKind::Tuple(tys) =>
+            Type { kind: TypeKind::Tuple(tys.into_iter().map(simplify_type).collect()), ..ty },
+        TypeKind::List(a) =>
+            Type { kind: TypeKind::List(Box::new(simplify_type(*a))), ..ty },
+        TypeKind::Set(a) =>
+            Type { kind: TypeKind::Set(Box::new(simplify_type(*a))), ..ty },
+        TypeKind::Dict(a, b) =>
+            Type { kind: TypeKind::Dict(Box::new(simplify_type(*a)), Box::new(simplify_type(*b))), ..ty },
 
-        TK::Implied
-        | TK::UserDefined(_)
-        | TK::Resolved(_)
-        | TK::Generic(_) => ty,
+        TypeKind::Implied
+        | TypeKind::UserDefined(_)
+        | TypeKind::Resolved(_)
+        | TypeKind::Generic(_) => ty,
     }
 }
 

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -92,8 +92,7 @@ fn simplify_type(ty: Type) -> Type {
         TK::Union(_, _) => {
             let without_dupes = remove_duplicates(ty.clone(), Vec::new());
             without_dupes.into_iter().reduce(|a, b| {
-                // Swap order so we nest to the right
-                Type { kind: TK::Union(Box::new(b), Box::new(a)), span: ty.span }
+                Type { kind: TK::Union(Box::new(a), Box::new(b)), span: ty.span }
             }).unwrap() // We always get one type
         }
 

--- a/tests/bugs/multiple_voids_411.sy
+++ b/tests/bugs/multiple_voids_411.sy
@@ -1,0 +1,3 @@
+start :: fn do
+    a: void | void | int | float = 1
+end

--- a/tests/bugs/multiple_voids_411.sy
+++ b/tests/bugs/multiple_voids_411.sy
@@ -1,3 +1,8 @@
 start :: fn do
     a: void | void | int | float = 1
+    b: int | int = 1
+    c: float | void | int? = 1
+    d: float | int? = 1
+    e: int = 1
+    f: {float | float: int | int | void | void?} = {:}
 end


### PR DESCRIPTION
Relates to #385 
```
start :: fn do
    a : int | void = 1
    a : float | void | int = 1
    b : void = nil
end
```