### PR TITLE
Formatter tweaks

### DIFF
--- a/sylt-macro/src/lib.rs
+++ b/sylt-macro/src/lib.rs
@@ -534,7 +534,7 @@ impl DocFile {
         use std::fs::File;
         use std::io::prelude::*;
         match File::create(&Path::new("docs/docs.json")) {
-            Err(_msg) => (), //TODO(gu) report errors
+            Err(_msg) => (), // TODO(gu) report errors
             Ok(mut file) => {
                 write!(file, "[\n{}\n]", self.docs.join(",\n")).unwrap();
             }

--- a/sylt-std/src/network.rs
+++ b/sylt-std/src/network.rs
@@ -250,7 +250,7 @@ pub fn n_rpc_client_ip(ctx: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     let ip = match ctx.machine.stack_from_base(ctx.stack_base).get(0) {
         Some(Value::String(s)) => SocketAddr::from_str(s.as_ref()).unwrap(),
         _ => {
-            return Ok(Value::Bool(false)); //TODO(gu): Type error here, probably.
+            return Ok(Value::Bool(false)); // TODO(gu): Type error here, probably.
         }
     };
 
@@ -282,7 +282,7 @@ pub fn n_rpc_client_ip(ctx: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     })
 }
 
-//TODO(gu): This doc is wrong since this takes variadic arguments.
+// TODO(gu): This doc is wrong since this takes variadic arguments.
 #[sylt_macro::sylt_doc(n_rpc_server, "Performs an RPC on the connected server, returning success status.", "fn #X, #Y -> bool")]
 #[sylt_macro::sylt_link(n_rpc_server, "sylt_std::network", "fn #X, #Y -> bool")]
 pub fn n_rpc_server(ctx: RuntimeContext<'_>) -> Result<Value, RuntimeError> {

--- a/sylt-std/src/sylt.rs
+++ b/sylt-std/src/sylt.rs
@@ -261,13 +261,13 @@ sylt_macro::extern_function!(
         let mut chars = s.chars();
         let c = match chars.next() {
             Some(c) => c,
-            //TODO(gu): Actually what went wrong
+            // TODO(gu): Actually what went wrong
             None => return Err(RuntimeError::ExternTypeMismatch("as_char".to_string(), vec![Type::String])),
         };
         if chars.next().is_none() {
             Ok(Int(c as i64))
         } else {
-            //TODO(gu): Actually what went wrong
+            // TODO(gu): Actually what went wrong
             Err(RuntimeError::ExternTypeMismatch("as_char".to_string(), vec![Type::String]))
         }
     }

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -424,7 +424,7 @@ fn write_statement<W: Write>(dest: &mut W, indent: u32, statement: Statement) ->
         StatementKind::Blob { name, fields } => {
             write_indents(dest, indent)?;
             write!(dest, "{} :: blob", name)?;
-            let fields_as_tuples = fields.iter().map(|(f, t)| (f.clone(), t.clone())).collect();
+            let fields_as_tuples = fields.into_iter().collect();
             write_blob_fields(dest, indent + 1, fields_as_tuples, write_type)?;
         }
         StatementKind::Block { statements } => {
@@ -549,8 +549,6 @@ fn write_statement<W: Write>(dest: &mut W, indent: u32, statement: Statement) ->
 }
 
 /// Replace consecutive empty statements with one empty statement with all comments of the previous statements.
-// TODO(gu): Rewrite the formatter to use moves instead of borrows. Then we wouldn't need to clone when passing
-//           into this function.
 fn merge_empty_statements(statements: Vec<Statement>) -> Vec<Statement> {
     use StatementKind::EmptyStatement;
     statements.iter().fold((Vec::new(), None),

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -637,7 +637,7 @@ macro_rules! test_formatter_on_file {
                 Err(errs) => {
                     eprintln!("The formatter couldn't parse the file but the syntax errors");
                     eprintln!("changed between before and after formatting.");
-                    let errs: Result<(), _> = Err(errs); //TODO(gu): Result<!, _> ;)
+                    let errs: Result<(), _> = Err(errs); // TODO(gu): Result<!, _> ;)
                     $crate::assert_errs!(errs, $errs);
                 }
             }

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -422,7 +422,6 @@ fn write_statement<W: Write>(dest: &mut W, indent: u32, statement: Statement) ->
             write_expression(dest, indent, value)?;
         }
         StatementKind::Blob { name, fields } => {
-            dbg!(&name);
             write_indents(dest, indent)?;
             write!(dest, "{} :: blob", name)?;
             let fields_as_tuples = fields.iter().map(|(f, t)| (f.clone(), t.clone())).collect();

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -548,7 +548,7 @@ fn write_statement<W: Write>(dest: &mut W, indent: u32, statement: Statement) ->
     Ok(())
 }
 
-/// Replace consecutive empty statements with one empty statement with all comments of the previous statements.
+/// Remove consecutive empty statements without comments
 fn merge_empty_statements(statements: Vec<Statement>) -> Vec<Statement> {
     use StatementKind::EmptyStatement;
     statements.into_iter().fold((Vec::new(), true),

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -54,10 +54,10 @@ fn write_parameters<W: Write>(
     Ok(())
 }
 
-fn write_blob_fields<T: Clone, W: Write>(
+fn write_blob_fields<T, W: Write>(
     dest: &mut W,
     indent: u32,
-    fields: Vec<(String, T)>,
+    mut fields: Vec<(String, T)>,
     sub_write: fn(&mut W, u32, T) -> fmt::Result,
 ) -> fmt::Result {
     write!(dest, " {{")?;
@@ -66,7 +66,7 @@ fn write_blob_fields<T: Clone, W: Write>(
             write!(dest, " }}")?;
         }
         1 => {
-            let (field, expr) = fields[0].clone();
+            let (field, expr) = fields.pop().unwrap();
             write!(dest, " {}: ", field)?;
             sub_write(dest, indent, expr)?;
             write!(dest, " }}")?;

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -60,14 +60,14 @@ fn write_blob_fields<T: Clone, W: Write>(
     fields: Vec<(String, T)>,
     sub_write: fn(&mut W, u32, T) -> fmt::Result,
 ) -> fmt::Result {
-    write!(dest, " {{ ")?;
+    write!(dest, " {{")?;
     match fields.len() {
         0 => {
             write!(dest, " }}")?;
         }
         1 => {
             let (field, expr) = fields[0].clone();
-            write!(dest, "{}: ", field)?;
+            write!(dest, " {}: ", field)?;
             sub_write(dest, indent, expr)?;
             write!(dest, " }}")?;
         }

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -479,7 +479,7 @@ fn write_statement<W: Write>(dest: &mut W, indent: u32, statement: Statement) ->
             }
             write_expression(dest, indent, value)?;
         }
-        StatementKind::EmptyStatement => {},
+        StatementKind::EmptyStatement => (),
         StatementKind::If {
             condition,
             pass,

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -551,17 +551,15 @@ fn write_statement<W: Write>(dest: &mut W, indent: u32, statement: Statement) ->
 /// Replace consecutive empty statements with one empty statement with all comments of the previous statements.
 fn merge_empty_statements(statements: Vec<Statement>) -> Vec<Statement> {
     use StatementKind::EmptyStatement;
-    statements.iter().fold((Vec::new(), None),
-        |(mut ret, prev): (Vec<Statement>, Option<&Statement>), stmt| {
-            let last_is_empty = prev.map_or(true, |s| matches!(s.kind, EmptyStatement));
+    statements.into_iter().fold((Vec::new(), true),
+        |(mut ret, prev_is_empty), stmt| {
+            let last_is_empty = prev_is_empty;
             let is_empty = matches!(stmt.kind, EmptyStatement);
             let no_comments = stmt.comments.is_empty();
-            if last_is_empty && is_empty && no_comments {
-                (ret, prev)
-            } else {
-                ret.push(stmt.clone());
-                (ret, Some(stmt))
+            if !(last_is_empty && is_empty && no_comments) {
+                ret.push(stmt);
             }
+            (ret, is_empty)
         }
     ).0
 }

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -394,7 +394,6 @@ fn write_expression<W: Write>(dest: &mut W, indent: u32, expression: Expression)
 }
 
 fn write_statement<W: Write>(dest: &mut W, indent: u32, statement: Statement) -> fmt::Result {
-    dbg!(&statement.comments);
     for comment in &statement.comments {
         write_indents(dest, indent)?;
         write!(dest, "// {}\n", comment)?;


### PR DESCRIPTION
Changed some things that bugged me about the formatter:
 - Statements now write out their own whitespace, this fixes the trailing whitespace bug and the combining of multiple blank statements work better
 - Blobs and Instances write their constructor on one line, if it's only 1 thing and now share code
 - Add a space in one of @sornas comments :3