### PR TITLE
Remove the sylt_doc-macro and docs.json-writer

### DIFF
--- a/sylt-std/src/network.rs
+++ b/sylt-std/src/network.rs
@@ -73,7 +73,6 @@ fn rpc_handle_stream(
     }
 }
 
-#[sylt_macro::sylt_doc(n_rpc_start_server, "Starts an RPC server on the specified port, returning success status.", "fn int -> bool")]
 #[sylt_macro::sylt_link(n_rpc_start_server, "sylt_std::network", "fn int -> bool")]
 pub fn n_rpc_start_server(ctx: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     // Get the port from the arguments.
@@ -124,7 +123,6 @@ pub fn n_rpc_stop_server(ctx: RuntimeContext<'_>) -> Result<Value, RuntimeError>
 }
 
 //NOTE(gu): We don't force a disconnect.
-#[sylt_macro::sylt_doc(n_rpc_connect, "Connects to an RPC server on the specified IP and port.", "fn str, int -> bool")]
 #[sylt_macro::sylt_link(n_rpc_connect, "sylt_std::network", "fn str, int -> bool")]
 pub fn n_rpc_connect(ctx: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     // Get the ip and port from the arguments.
@@ -169,7 +167,6 @@ pub fn n_rpc_connect(ctx: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     Ok(Value::Bool(true))
 }
 
-#[sylt_macro::sylt_doc(n_rpc_is_server, "Returns whether we've started a server or not.", "fn -> bool")]
 #[sylt_macro::sylt_link(n_rpc_is_server, "sylt_std::network", "fn -> bool")]
 pub fn n_rpc_is_server(_: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     Ok(Value::Bool(
@@ -177,7 +174,6 @@ pub fn n_rpc_is_server(_: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     ))
 }
 
-#[sylt_macro::sylt_doc(n_rpc_connected_clients, "Returns how many clients are currently connected.", "fn -> int")]
 #[sylt_macro::sylt_link(n_rpc_connected_clients, "sylt_std::network", "fn -> int")]
 pub fn n_rpc_connected_clients(_: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     Ok(Value::Int(CLIENT_HANDLES.with(|handles| {
@@ -190,7 +186,6 @@ pub fn n_rpc_connected_clients(_: RuntimeContext<'_>) -> Result<Value, RuntimeEr
     })))
 }
 
-#[sylt_macro::sylt_doc(n_rpc_is_client, "Returns whether we've connected to a client or not.", "fn -> bool")]
 #[sylt_macro::sylt_link(n_rpc_is_client, "sylt_std::network", "fn -> bool")]
 pub fn n_rpc_is_client(_: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     Ok(Value::Bool(
@@ -213,7 +208,6 @@ fn get_rpc_args(ctx: RuntimeContext<'_>, arg_offset: usize, func_name: &str) -> 
     }
 }
 
-#[sylt_macro::sylt_doc(n_rpc_clients, "Performs an RPC on all connected clients.", "fn #X, [#Y] -> void")]
 #[sylt_macro::sylt_link(n_rpc_clients, "sylt_std::network", "fn #X, [#Y] -> void")]
 pub fn n_rpc_clients(ctx: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     // Serialize the RPC.
@@ -244,7 +238,6 @@ pub fn n_rpc_clients(ctx: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
 }
 
 
-#[sylt_macro::sylt_doc(n_rpc_client_ip, "Performs an RPC on a specific connected clients.", "fn #X, [#Y] -> bool")]
 #[sylt_macro::sylt_link(n_rpc_client_ip, "sylt_std::network", "fn #X, [#Y] -> bool")]
 pub fn n_rpc_client_ip(ctx: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     let ip = match ctx.machine.stack_from_base(ctx.stack_base).get(0) {
@@ -283,7 +276,6 @@ pub fn n_rpc_client_ip(ctx: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
 }
 
 // TODO(gu): This doc is wrong since this takes variadic arguments.
-#[sylt_macro::sylt_doc(n_rpc_server, "Performs an RPC on the connected server, returning success status.", "fn #X, #Y -> bool")]
 #[sylt_macro::sylt_link(n_rpc_server, "sylt_std::network", "fn #X, #Y -> bool")]
 pub fn n_rpc_server(ctx: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     // Serialize the RPC.
@@ -311,7 +303,6 @@ pub fn n_rpc_server(ctx: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     })
 }
 
-#[sylt_macro::sylt_doc(n_rpc_disconnect, "Disconnect from the currently connected server.", "fn -> void")]
 #[sylt_macro::sylt_link(n_rpc_disconnect, "sylt_std::network", "fn -> void")]
 pub fn n_rpc_disconnect(_: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     SERVER_HANDLE.with(|server_handle| {
@@ -325,7 +316,6 @@ pub fn n_rpc_disconnect(_: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     Ok(Value::Nil)
 }
 
-#[sylt_macro::sylt_doc(n_rpc_current_request_ip, "Get the socket address that sent the currently processed RPC. Empty string if not a server or not processing an RPC.", "fn -> str")]
 #[sylt_macro::sylt_link(n_rpc_current_request_ip, "sylt_std::network", "fn -> str")]
 pub fn n_rpc_current_request_ip(_: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     CURRENT_REQUEST_SOCKET_ADDR.with(|current|
@@ -353,7 +343,6 @@ sylt_macro::extern_function!(
 );
 
 
-#[sylt_macro::sylt_doc(n_rpc_resolve, "Resolves the queued RPCs that has been received since the last resolve.", "fn -> void")]
 #[sylt_macro::sylt_link(n_rpc_resolve, "sylt_std::network", "fn -> void")]
 pub fn n_rpc_resolve(ctx: RuntimeContext<'_>) -> Result<Value, RuntimeError> {
     // Take the current queue.


### PR DESCRIPTION
I opted to keep the documentation string in the extern_function-macro
but it can be removed with some manual labour.