### PR TITLE
Add external definitions

### DIFF
--- a/sylt-compiler/src/bytecode.rs
+++ b/sylt-compiler/src/bytecode.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::rc::Rc;
 use sylt_common::error::Error;
 use sylt_common::{Block, Op, Type, Value};
@@ -377,6 +379,13 @@ impl<'t> BytecodeCompiler<'t> {
                     let op = Op::ReadGlobal(*slot);
                     self.add_op(ctx, span, op);
                 }
+                Some(Name::External(_)) => {
+                    error!(
+                        self.compiler,
+                        ctx, span,
+                        "External values aren't allowed when compiling to byte-code "
+                    );
+                }
                 Some(Name::Blob(blob)) => {
                     let op = Op::Constant(*blob);
                     self.add_op(ctx, span, op);
@@ -498,6 +507,16 @@ impl<'t> BytecodeCompiler<'t> {
                     let slot = self.compiler.define(&ident.name, *kind, statement.span);
                     self.compiler.activate(slot);
                 }
+            }
+
+            #[rustfmt::skip]
+            ExternalDefinition { .. } => {
+                // TODO(ed): Should they be? Is this how we should type the standard library?
+                error!(
+                    self.compiler,
+                    ctx, statement.span,
+                    "External values aren't allowed when compiling to byte-code "
+                );
             }
 
             #[rustfmt::skip]
@@ -737,16 +756,17 @@ impl<'t> BytecodeCompiler<'t> {
 // TODO(ed): This should move to the typechecker - since we always want this check.
 fn all_paths_return(statement: &Statement) -> bool {
     match &statement.kind {
-        StatementKind::Use { .. }
-        | StatementKind::Blob { .. }
-        | StatementKind::IsCheck { .. }
         | StatementKind::Assignment { .. }
+        | StatementKind::Blob { .. }
+        | StatementKind::Break
+        | StatementKind::Continue
         | StatementKind::Definition { .. }
+        | StatementKind::EmptyStatement
+        | StatementKind::ExternalDefinition { .. }
+        | StatementKind::IsCheck { .. }
         | StatementKind::StatementExpression { .. }
         | StatementKind::Unreachable
-        | StatementKind::Continue
-        | StatementKind::Break
-        | StatementKind::EmptyStatement => false,
+        | StatementKind::Use { .. } => false,
 
         StatementKind::If { pass, fail, .. } => all_paths_return(pass) && all_paths_return(fail),
 

--- a/sylt-compiler/src/bytecode.rs
+++ b/sylt-compiler/src/bytecode.rs
@@ -509,7 +509,6 @@ impl<'t> BytecodeCompiler<'t> {
                 }
             }
 
-            #[rustfmt::skip]
             ExternalDefinition { .. } => {
                 // TODO(ed): Should they be? Is this how we should type the standard library?
                 error!(

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -107,6 +107,7 @@ type BlobID = usize;
 type BlockID = usize;
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 enum Name {
+    External(VarKind),
     Global(ConstantID),
     Blob(BlobID),
     Namespace(NamespaceID),
@@ -578,6 +579,12 @@ impl Compiler {
                         self.activate(var);
                         num_constants += 1;
                         (Name::Global(var), name.clone(), statement.span)
+                    }
+                    ExternalDefinition { ident: Identifier { name, .. }, kind, .. } => {
+                        let var = self.define(name, *kind, statement.span);
+                        self.activate(var);
+                        num_constants += 1;
+                        (Name::External(*kind), name.clone(), statement.span)
                     }
 
                     // Handled later since we need type information.

--- a/sylt-compiler/src/dependency.rs
+++ b/sylt-compiler/src/dependency.rs
@@ -236,15 +236,15 @@ fn order(
                 State::Inserted => Ok(()),
             },
         };
-        if let Some((deps, statement)) = to_order.get(&name) {
-            for dep in deps {
-                recurse(*dep, to_order, inserted, ordered)
-                    .map_err(|mut cycle| { cycle.push(*statement); cycle })?;
-            }
-            ordered.push(*statement);
-        }
 
+        (deps, statement) = to_order.get(&name).expect("Trying to find an identifier that does not exist");
+        for dep in deps {
+            recurse(*dep, to_order, inserted, ordered)
+                .map_err(|mut cycle| { cycle.push(*statement); cycle })?;
+        }
+        ordered.push(*statement);
         inserted.insert(name, State::Inserted);
+
         Ok(())
     }
 

--- a/sylt-compiler/src/dependency.rs
+++ b/sylt-compiler/src/dependency.rs
@@ -128,7 +128,6 @@ fn statement_dependencies(ctx: &mut Context, statement: &Statement) -> BTreeSet<
             dependencies(ctx, value)
         },
 
-
         | Ret { value }
         | StatementExpression { value } => dependencies(ctx, value),
 

--- a/sylt-compiler/src/lua.rs
+++ b/sylt-compiler/src/lua.rs
@@ -461,26 +461,3 @@ impl<'t> LuaCompiler<'t> {
         write!(self, ";");
     }
 }
-
-// TODO(ed): This should move to the typechecker - since we always want this check.
-fn all_paths_return(statement: &Statement) -> bool {
-    match &statement.kind {
-        StatementKind::Use { .. }
-        | StatementKind::Blob { .. }
-        | StatementKind::IsCheck { .. }
-        | StatementKind::Assignment { .. }
-        | StatementKind::Definition { .. }
-        | StatementKind::StatementExpression { .. }
-        | StatementKind::Unreachable
-        | StatementKind::Continue
-        | StatementKind::Break
-        | StatementKind::EmptyStatement => false,
-
-        StatementKind::If { pass, fail, .. } => all_paths_return(pass) && all_paths_return(fail),
-
-        StatementKind::Loop { body, .. } => all_paths_return(body),
-        StatementKind::Block { statements } => statements.iter().any(all_paths_return),
-
-        StatementKind::Ret { .. } => true,
-    }
-}

--- a/sylt-compiler/src/lua.rs
+++ b/sylt-compiler/src/lua.rs
@@ -268,16 +268,15 @@ impl<'t> LuaCompiler<'t> {
                 Some(Name::Blob(blob)) => {
                     self.write_global(blob);
                 }
+                Some(Name::External(_)) => {
+                    write!(self, "{}", name);
+                }
                 Some(Name::Namespace(new_namespace)) => {
                     return Some(new_namespace)
                 }
                 None => {
-                    if name == "print" {
-                        write!(self, "print");
-                    } else {
-                        error!(self.compiler, ctx, span, "No identifier found named: '{}'", name);
-                        dbg!(&self.compiler.frames);
-                    }
+                    error!(self.compiler, ctx, span, "No identifier found named: '{}'", name);
+                    dbg!(&self.compiler.frames);
                 }
             },
         }
@@ -334,6 +333,9 @@ impl<'t> LuaCompiler<'t> {
             }
 
             #[rustfmt::skip]
+            ExternalDefinition { .. } => {}
+
+            #[rustfmt::skip]
             Definition { ident, value, .. } => {
                 self.set_identifier(&ident.name, statement.span, ctx, ctx.namespace);
                 write!(self, "=");
@@ -359,11 +361,11 @@ impl<'t> LuaCompiler<'t> {
         match &statement.kind {
             Use { .. } | EmptyStatement => {}
 
-            Blob { name, fields } => {
+            Blob { .. } => {
                 todo!();
             }
 
-            IsCheck { lhs, rhs } => {
+            IsCheck { .. } => {
                 todo!();
             }
 
@@ -375,6 +377,11 @@ impl<'t> LuaCompiler<'t> {
                 write!(self, "=");
                 self.expression(value, ctx);
                 self.compiler.activate(slot);
+            }
+
+            #[rustfmt::skip]
+            ExternalDefinition { .. } => {
+                error!(self.compiler, ctx, statement.span, "External definitions must lie in the outmost scope");
             }
 
             #[rustfmt::skip]
@@ -400,12 +407,12 @@ impl<'t> LuaCompiler<'t> {
                 self.compiler.frames.last_mut().unwrap().variables.truncate(s);
             }
 
-            Loop { condition, body } => {
+            Loop { .. } => {
                 todo!();
             }
 
             #[rustfmt::skip]
-            If { condition, pass, fail } => {
+            If { .. } => {
                 todo!();
             }
 
@@ -443,8 +450,8 @@ impl<'t> LuaCompiler<'t> {
 
     pub fn preamble(
         &mut self,
-        span: Span,
-        num_constants: usize,
+        _span: Span,
+        _num_constants: usize,
     ) {
     }
 

--- a/sylt-compiler/src/lua.rs
+++ b/sylt-compiler/src/lua.rs
@@ -332,7 +332,6 @@ impl<'t> LuaCompiler<'t> {
                 todo!();
             }
 
-            #[rustfmt::skip]
             ExternalDefinition { .. } => {}
 
             #[rustfmt::skip]
@@ -379,7 +378,6 @@ impl<'t> LuaCompiler<'t> {
                 self.compiler.activate(slot);
             }
 
-            #[rustfmt::skip]
             ExternalDefinition { .. } => {
                 error!(self.compiler, ctx, statement.span, "External definitions must lie in the outmost scope");
             }

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1009,7 +1009,6 @@ impl<'c> TypeChecker<'c> {
                     // so we don't have to care about the duplicates.
                     x => unreachable!("X: {:?}", x),
                 };
-                println!("----");
                 self.namespaces[namespace].insert(ident.name.clone(), Name::Global(Some(name)));
             }
 

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -63,7 +63,7 @@ pub enum Prec {
 ///
 /// Forced variable kinds are a signal to the type checker that the type is
 /// assumed and shouldn't be checked.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum VarKind {
     Const,
     Mutable,
@@ -1083,6 +1083,10 @@ impl PrettyPrint for Statement {
             SK::Definition { ident, kind, ty, value } => {
                 write!(f, "<Def> {} {:?} {}\n", ident.name, kind, ty)?;
                 value.pretty_print(f, indent + 1)?;
+                return Ok(());
+            }
+            SK::ExternalDefinition { ident, kind, ty } => {
+                write!(f, "<ExtDef> {} {:?} {}\n", ident.name, kind, ty)?;
                 return Ok(());
             }
             SK::Assignment { kind, target, value } => {

--- a/sylt-tokenizer/src/token.rs
+++ b/sylt-tokenizer/src/token.rs
@@ -142,6 +142,8 @@ pub enum Token {
     From,
     #[token("as")]
     As,
+    #[token("external")]
+    External,
 
     #[token("<<<<<<<")]
     GitConflictBegin,

--- a/sylt/src/formatter.rs
+++ b/sylt/src/formatter.rs
@@ -491,6 +491,25 @@ fn write_statement<W: Write>(dest: &mut W, indent: u32, statement: Statement) ->
             write_indents(dest, indent)?;
             write!(dest, "continue")?
         }
+        StatementKind::ExternalDefinition {
+            ident,
+            kind,
+            ty,
+        } => {
+            assert!(!matches!(ty.kind, TypeKind::Implied), "Should not parse");
+            assert!(!kind.force(), "Should not parse");
+
+            write_indents(dest, indent)?;
+            write_identifier(dest, ident)?;
+            write!(dest, ": ")?;
+            write_type(dest, indent, ty)?;
+            if kind.immutable() {
+                write!(dest, " : ")?;
+            } else {
+                write!(dest, " = ")?;
+            }
+            write!(dest, "external")?;
+        }
         StatementKind::Definition {
             ident,
             kind,


### PR DESCRIPTION
Adds syntax for external definition - merged directly into the Lua branch since that's where it's needed ATM.

See this more as a sanity check, so come with opinion on the syntax.

Testing this is hard right now - but I'll add some lua tests when we get there!