### PR TITLE
Guide fix colors

### DIFF
--- a/docs/stylesheet.css
+++ b/docs/stylesheet.css
@@ -1103,7 +1103,7 @@ h3 > a.link:hover,
 h4 > a.link:hover,
 h5 > a.link:hover,
 h6 > a.link:hover {
-  color: #a53221;
+  color: var(--primaryhover);
 }
 
 details,
@@ -2446,6 +2446,8 @@ p.tableblock {
   --primarycolor: #FF4B4F;
   --secondarycolor: #FF4B4F;
   --tertiarycolor: #FF4B4F;
+
+  --primaryhover: #c5363a;
 
   --linkcolor: #efca44;
   --linkhover: #a78d2f;


### PR DESCRIPTION
Some of the colors for `admonitionblock` were hard to read. So I changed them a bit. Now it looks like this:
![image](https://user-images.githubusercontent.com/19999497/137214585-87798f6b-fd5f-4940-9243-962d524e8b74.png)
