### PR TITLE
Lua Definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The short version:
  - Simplicity in the syntax
  - C-style syntax with the taste of functional
 
-Sylt has become a mix of functional-programming concepts 
+Sylt has become a mix of functional-programming concepts
 mixed with more procedural code. The language itself is very small
 but still expressive. The typechecker is what sets it apart from
 Python and Lua, which usually end up being used for similar use-cases.
@@ -30,7 +30,7 @@ the typechecker will be all fine with it.
 
 This is meant to give the same rapid iteration speed as working in something
 like Python or Lua, but with the added peace of mind a strict static
-typechecker gives you. 
+typechecker gives you.
 
 # Sylt and game jams
 The language is made for game jams, and has been used in multiple. Unfortunately

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -101,6 +101,7 @@ impl Compiler {
             Statement::Assignment { .. }
             | Statement::Definition { .. }
             | Statement::ExternalDefinition { .. }
+            | Statement::LuaDefinition { .. }
             | Statement::Loop { .. }
             | Statement::Break(_)
             | Statement::Continue(_)
@@ -109,6 +110,7 @@ impl Compiler {
             | Statement::StatementExpression { .. }
             | Statement::Unreachable(_) => 1,
         });
+
 
         let typechecker = typechecker::solve(&vars, &statements, &self.namespace_id_to_file)?;
 

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -111,7 +111,6 @@ impl Compiler {
             | Statement::Unreachable(_) => 1,
         });
 
-
         let typechecker = typechecker::solve(&vars, &statements, &self.namespace_id_to_file)?;
 
         let ir = intermediate::compile(&typechecker, &statements);

--- a/sylt-compiler/src/dependency.rs
+++ b/sylt-compiler/src/dependency.rs
@@ -43,6 +43,7 @@ fn statement_dependencies(statement: &Statement) -> BTreeSet<usize> {
         S::Blob { .. }
         | S::Enum { .. }
         | S::ExternalDefinition { .. }
+        | S::LuaDefinition { .. }
         | S::Break(..)
         | S::Continue(..)
         | S::Unreachable(..) => BTreeSet::new(),
@@ -242,6 +243,7 @@ pub(crate) fn initialization_order<'a>(
         use Statement as S;
         match &statement {
             S::ExternalDefinition { var, .. }
+            | S::LuaDefinition { var, .. }
             | S::Definition { var, .. }
             | S::Blob { var, .. }
             | S::Enum { var, .. } => {

--- a/sylt-compiler/src/intermediate.rs
+++ b/sylt-compiler/src/intermediate.rs
@@ -38,6 +38,7 @@ pub enum IR {
     Not(Var, Var),
 
     External(Var, String),
+    Lua(Var, String),
     Call(Var, Var, Vec<Var>),
 
     Equals(Var, Var, Var),
@@ -548,7 +549,10 @@ impl<'a> IRCodeGen<'a> {
 
             S::StatementExpression { value, .. } => self.expression(value, ctx).0,
 
-            S::Blob { .. } | S::Enum { .. } | S::ExternalDefinition { .. } => unreachable!(),
+            S::Blob { .. }
+            | S::Enum { .. }
+            | S::ExternalDefinition { .. }
+            | S::LuaDefinition { .. } => unreachable!(),
         }
     }
 
@@ -558,6 +562,10 @@ impl<'a> IRCodeGen<'a> {
         match &stmt {
             S::ExternalDefinition { name, var, .. } => {
                 vec![IR::External(Var(*var), name.clone())]
+            }
+
+            S::LuaDefinition { var, lua, .. } => {
+                vec![IR::Lua(Var(*var), lua.clone())]
             }
 
             S::Definition { value, var, .. } => self.definition(Var(*var), value, ctx),
@@ -607,6 +615,7 @@ pub(crate) fn count_usages(ops: &[IR]) -> HashMap<Var, usize> {
             | IR::Else
             | IR::End
             | IR::External(_, _)
+            | IR::Lua(_, _)
             | IR::Label(_)
             | IR::Goto(_)
             | IR::HaltAndCatchFire(_) => {}

--- a/sylt-compiler/src/lua.rs
+++ b/sylt-compiler/src/lua.rs
@@ -174,6 +174,13 @@ impl<'a, 'b> Generator<'a, 'b> {
                     write!(self.out, e);
                 }
 
+                IR::Lua(t, lua) => {
+                    let t = self.expand(t);
+                    write!(self.out, "{}", t);
+                    write!(self.out, " = ");
+                    write!(self.out, "(function () {} end)()", lua);
+                }
+
                 IR::Call(t, f, args) => {
                     write!(self.out, "local ");
                     let t = self.expand(t);

--- a/sylt-compiler/src/lua.rs
+++ b/sylt-compiler/src/lua.rs
@@ -115,7 +115,9 @@ impl<'a, 'b> Generator<'a, 'b> {
 
                 IR::Neg(t, a) => ii!(self, t, "(-{})", a),
 
-                IR::Str(t, s) => iis!(self, t, "\"{}\"", s),
+                // Replace newlines in strings with \n in lua, since lua strings don't continue on
+                // the next line
+                IR::Str(t, s) => iis!(self, t, "\"{}\"", s.replace("\n", r"\n")),
                 IR::Float(t, f) => iis!(self, t, "{:?}", f),
 
                 IR::Equals(t, a, b) => ii!(self, t, "({} == {})", a, b),

--- a/sylt-compiler/src/name_resolution.rs
+++ b/sylt-compiler/src/name_resolution.rs
@@ -304,7 +304,7 @@ pub enum Statement {
         span: Span,
     },
 
-    /// Defines a an external variable - here the type is required.
+    /// Defines an external variable - here the type is required.
     ///
     /// Example: `a: int = external`.
     ///
@@ -317,6 +317,16 @@ pub enum Statement {
         span: Span,
     },
 
+    /// Defines a variable with result of lua code (wrapped in a function).
+    ///
+    /// Example:
+    /// ```
+    /// v: void : `
+    ///     local v = 1
+    ///     print("side effect")
+    ///     return function() print("hello") end
+    /// `
+    /// ```
     LuaDefinition {
         name: String,
         var: Ref,

--- a/sylt-parser/src/parser.rs
+++ b/sylt-parser/src/parser.rs
@@ -1395,6 +1395,10 @@ impl PrettyPrint for Statement {
                 write!(f, "<ExtDef> {} {:?} {}\n", ident.name, kind, ty)?;
                 return Ok(());
             }
+            SK::LuaDefinition { ident, kind, ty, lua } => {
+                write!(f, "<LuaDef> {} {:?} {} `{}`\n", ident.name, kind, ty, lua)?;
+                return Ok(());
+            }
             SK::Assignment { kind, target, value } => {
                 write!(f, "<Ass> {:?}\n", kind)?;
                 target.pretty_print(f, indent + 1)?;

--- a/sylt-parser/src/statement.rs
+++ b/sylt-parser/src/statement.rs
@@ -117,11 +117,11 @@ pub enum StatementKind {
     ///
     /// Example:
     /// ```
-    /// v: void : lua
+    /// v: void : `
     ///     local v = 1
     ///     print("side effect")
     ///     return function() print("hello") end
-    /// luaend
+    /// `
     /// ```
     LuaDefinition {
         ident: Identifier,
@@ -686,18 +686,18 @@ pub fn statement<'t>(ctx: Context<'t>) -> ParseResult<'t, Statement> {
                 (ctx.skip(1), kind, ty)
             };
 
-            if matches!(ctx.token(), T::External) {
-                (ctx.skip(1), ExternalDefinition { ident, kind, ty })
-            } else if let T::Lua(lua) = ctx.token() {
-                (
+            match ctx.token() {
+                T::External => (ctx.skip(1), ExternalDefinition { ident, kind, ty }),
+                T::Lua(lua) => (
                     ctx.skip(1),
                     LuaDefinition { ident, kind, ty, lua: lua.clone() },
-                )
-            } else {
-                // The value to define the variable to.
-                let (ctx, value) = expression(ctx)?;
+                ),
+                _ => {
+                    // The value to define the variable to.
+                    let (ctx, value) = expression(ctx)?;
 
-                (ctx, Definition { ident, kind, ty, value })
+                    (ctx, Definition { ident, kind, ty, value })
+                }
             }
         }
 

--- a/sylt-tokenizer/src/token.rs
+++ b/sylt-tokenizer/src/token.rs
@@ -163,6 +163,9 @@ pub enum Token {
     #[token("external")]
     External,
 
+    #[regex(r"`[^`]*`", |lex| { let mut s = lex.slice().to_string(); s.remove(0); s.pop(); s })]
+    Lua(String),
+
     #[token("<<<<<<<")]
     GitConflictBegin,
     #[token(">>>>>>>")]

--- a/sylt-tokenizer/src/token.rs
+++ b/sylt-tokenizer/src/token.rs
@@ -16,7 +16,7 @@ pub enum Token {
     #[token("str")]
     StrType,
 
-    #[regex(r#""[^"]*""#, |lex| { let mut s = lex.slice().to_string(); s.remove(0); s.pop(); s })]
+    #[regex(r#""(?:[^"\\]|\\.)*""#, |lex| { let mut s = lex.slice().to_string(); s.remove(0); s.pop(); s })]
     String(String),
 
     // `X.`, `.Y`, `X.Y`, `XeY` and `Xe-Y`

--- a/sylt/docs/docs.css
+++ b/sylt/docs/docs.css
@@ -11,7 +11,6 @@ body {
     padding-top: calc(1em - 0.5em);
     padding-bottom: 1em;
     border-radius: 5px;
-    
 }
 
 .sigs li {

--- a/tests/lua/basic.sy
+++ b/tests/lua/basic.sy
@@ -1,0 +1,5 @@
+a : int : `return 1`
+
+start :: fn do
+    1 <=> a
+end

--- a/tests/lua/faulty_error.sy
+++ b/tests/lua/faulty_error.sy
@@ -1,0 +1,17 @@
+a : bool : `
+    local a = true
+    return true
+`
+
+b : bool : `
+    local x = true
+    `
+    return x
+`
+
+start :: fn do
+    print' a
+end
+
+// error: @4
+// error: @5

--- a/tests/lua/multiline.sy
+++ b/tests/lua/multiline.sy
@@ -1,0 +1,10 @@
+a : bool : `
+    local a = 2
+    local b = 3
+    
+    return a < b
+`
+
+start :: fn do
+    a <=> true
+end

--- a/tests/lua/multiline.sy
+++ b/tests/lua/multiline.sy
@@ -1,7 +1,7 @@
 a : bool : `
     local a = 2
     local b = 3
-    
+
     return a < b
 `
 

--- a/tests/lua/string.sy
+++ b/tests/lua/string.sy
@@ -1,0 +1,6 @@
+a : str : `return "quotation: \" <-"`
+b :: "quotation: \" <-"
+
+start :: fn do
+    a <=> b
+end

--- a/tests/lua/string.sy
+++ b/tests/lua/string.sy
@@ -1,6 +1,16 @@
-a : str : `return "quotation: \" <-"`
-b :: "quotation: \" <-"
+lua1 : str : `return "quotation: \" <-"`
+sylt1 :: "quotation: \" <-"
+
+lua2 : str : `return "newline: \n"`
+sylt2 : str : "newline: \n"
+
+lua3 : str : `return [[multi
+line]]`
+sylt3 : str : "multi
+line"
 
 start :: fn do
-    a <=> b
+    lua1 <=> sylt1
+    lua2 <=> sylt2
+    lua3 <=> sylt3
 end


### PR DESCRIPTION
# Allow lua definitions in Sylt code.

Examples:

```
a : int : `return 1`
```

```
a : bool : `
    local a = 0
    local b = 1
    return a < b
`
```

## Bugs

- Only works as an outer statement. This is a bug in the current implementation. Maybe it
  should only work as an outer statement however?

## Thoughts

- Beginning with `lua` and ending with `luaend` is cleaner, I think, but it
  might be hard to do since `logos` does not support look-around or non-greedy
  matching in regexes (from what I can find anyway).
- Should inline lua be in functions? It is nice because you get a more narrow
  scope and you can do side effects cleanly, kind of? The fact that only
  lua definitions are allowed (in sylt) makes side effects kinda weird in this case.
- Should it be an expression to allow for lua side effects
  in sylt functions?
- Should the lua be parsed to check for errors?

# Other

- Allow escaping strings with `\"`, like: `" -> \" <- "`
- Allow multi line strings in sylt, before it would all work except for the
  generated lua code.
