### PR TITLE
Cylt-lang

### DIFF
--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -74,7 +74,7 @@ impl Compiler {
         assert!(!tree.modules.is_empty(), "Cannot compile an empty program");
 
         self.extract_namespaces(&tree);
-        let (vars, statements) = name_resolution::resolve(&tree, &self.namespace_id_to_file)?;
+        let (vars, num_types, statements) = name_resolution::resolve(&tree, &self.namespace_id_to_file)?;
 
         // TODO[ed]: These clones are unneeded!
         let statements = match dependency::initialization_order(&statements) {
@@ -110,7 +110,7 @@ impl Compiler {
             | Statement::Unreachable(_) => 1,
         });
 
-        let typechecker = typechecker::solve(&vars, &mut statements, &self.namespace_id_to_file)?;
+        let typechecker = typechecker::solve(&vars, num_types, &statements, &self.namespace_id_to_file)?;
 
         let (ir, var_to_name) = intermediate::compile(&typechecker, &statements);
         let usage_count = intermediate::count_usages(&ir);

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -110,9 +110,9 @@ impl Compiler {
             | Statement::Unreachable(_) => 1,
         });
 
-        let typechecker = typechecker::solve(&vars, num_types, &statements, &self.namespace_id_to_file)?;
+        let mut typechecker = typechecker::solve(&vars, num_types, &statements, &self.namespace_id_to_file)?;
 
-        let (ir, var_to_name) = intermediate::compile(&typechecker, &statements);
+        let (ir, var_to_name) = intermediate::compile(&mut typechecker, &statements);
         let usage_count = intermediate::count_usages(&ir);
 
         lua::generate(&ir, &var_to_name, &usage_count, lua_file, require);

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -112,10 +112,10 @@ impl Compiler {
 
         let typechecker = typechecker::solve(&vars, &statements, &self.namespace_id_to_file)?;
 
-        let ir = intermediate::compile(&typechecker, &statements);
+        let (ir, var_to_name) = intermediate::compile(&typechecker, &statements);
         let usage_count = intermediate::count_usages(&ir);
 
-        lua::generate(&ir, &usage_count, lua_file, require);
+        lua::generate(&ir, &var_to_name, &usage_count, lua_file, require);
 
         Ok(())
     }

--- a/sylt-compiler/src/compiler.rs
+++ b/sylt-compiler/src/compiler.rs
@@ -110,7 +110,7 @@ impl Compiler {
             | Statement::Unreachable(_) => 1,
         });
 
-        let typechecker = typechecker::solve(&vars, &statements, &self.namespace_id_to_file)?;
+        let typechecker = typechecker::solve(&vars, &mut statements, &self.namespace_id_to_file)?;
 
         let (ir, var_to_name) = intermediate::compile(&typechecker, &statements);
         let usage_count = intermediate::count_usages(&ir);

--- a/sylt-compiler/src/dependency.rs
+++ b/sylt-compiler/src/dependency.rs
@@ -75,7 +75,7 @@ fn ty_dependency(ty: &Type) -> BTreeSet<usize> {
 fn dependencies(expression: &Expression) -> BTreeSet<usize> {
     use Expression as E;
     match &expression {
-        E::Read { var, .. } => [*var].iter().map(|v| *v).collect(),
+        E::Read { var, .. } | E::ReadUpvalue { var, .. } => [*var].iter().map(|v| *v).collect(),
         E::Variant { ty, value, .. } => dependencies(value)
             .iter()
             .chain([*ty].iter())

--- a/sylt-compiler/src/dependency.rs
+++ b/sylt-compiler/src/dependency.rs
@@ -76,9 +76,9 @@ fn dependencies(expression: &Expression) -> BTreeSet<usize> {
     use Expression as E;
     match &expression {
         E::Read { var, .. } | E::ReadUpvalue { var, .. } => [*var].iter().map(|v| *v).collect(),
-        E::Variant { ty, value, .. } => dependencies(value)
+        E::Variant { enum_ty, value, .. } => dependencies(value)
             .iter()
-            .chain([*ty].iter())
+            .chain([*enum_ty].iter())
             .cloned()
             .collect(),
         E::Call { function, args, .. } => dependencies(function)
@@ -177,7 +177,9 @@ fn dependencies(expression: &Expression) -> BTreeSet<usize> {
             .collect(),
 
         // No dependencies
-        E::Float(_, _) | E::Int(_, _) | E::Str(_, _) | E::Bool(_, _) | E::Nil(_) => BTreeSet::new(),
+        E::Float { .. } | E::Int { .. } | E::Str { .. } | E::Bool { .. } | E::Nil { .. } => {
+            BTreeSet::new()
+        }
     }
 }
 

--- a/sylt-compiler/src/intermediate.rs
+++ b/sylt-compiler/src/intermediate.rs
@@ -469,26 +469,26 @@ impl<'a> IRCodeGen<'a> {
                 )
             }
 
-            E::Float(a, _) => {
+            E::Float { value, .. } => {
                 let var = self.var();
-                (vec![IR::Float(var, *a)], var)
+                (vec![IR::Float(var, *value)], var)
             }
-            E::Str(a, _) => {
+            E::Str { value, .. } => {
                 let var = self.var();
-                (vec![IR::Str(var, a.into())], var)
+                (vec![IR::Str(var, value.into())], var)
             }
 
-            E::Bool(b, _) => {
+            E::Bool { value, .. } => {
                 let a = self.var();
-                (vec![IR::Bool(a, *b)], a)
+                (vec![IR::Bool(a, *value)], a)
             }
 
-            E::Int(i, _) => {
+            E::Int { value, .. } => {
                 let a = self.var();
-                (vec![IR::Int(a, *i)], a)
+                (vec![IR::Int(a, *value)], a)
             }
 
-            E::Nil(_) => {
+            E::Nil { .. } => {
                 let a = self.var();
                 (vec![IR::Nil(a)], a)
             }
@@ -560,11 +560,11 @@ impl<'a> IRCodeGen<'a> {
                     | E::Function { .. }
                     | E::Blob { .. }
                     | E::Collection { .. }
-                    | E::Float(_, _)
-                    | E::Int(_, _)
-                    | E::Str(_, _)
-                    | E::Bool(_, _)
-                    | E::Nil(_) => {
+                    | E::Float { .. }
+                    | E::Int { .. }
+                    | E::Str { .. }
+                    | E::Bool { .. }
+                    | E::Nil { .. } => {
                         unreachable!("Not assignable, should be caught in the name_resolver")
                     }
                 };

--- a/sylt-compiler/src/intermediate.rs
+++ b/sylt-compiler/src/intermediate.rs
@@ -525,7 +525,11 @@ impl<'a> IRCodeGen<'a> {
                         let source = Var(*var);
                         let dest = self.var();
                         self.name_var(dest, name.clone());
-                        (vec![IR::CopyUpvalue(dest, upvalue_index, source)], dest, vec![IR::AssignUpvalue(Var(*var), upvalue_index, res)])
+                        (
+                            vec![IR::CopyUpvalue(dest, upvalue_index, source)],
+                            dest,
+                            vec![IR::AssignUpvalue(Var(*var), upvalue_index, res)],
+                        )
                     }
                     E::Index { value, index, .. } => {
                         let (aops, a) = self.expression(value, ctx);

--- a/sylt-compiler/src/intermediate.rs
+++ b/sylt-compiler/src/intermediate.rs
@@ -154,7 +154,7 @@ impl<'a> IRCodeGen<'a> {
         use Expression as E;
         use Statement as S;
         match &expr {
-            E::Read { var, name, .. } => {
+            E::Read { var, name, .. } | E::ReadUpvalue { var, name, .. } => {
                 let source = Var(*var);
                 self.name_var(source, name.clone());
                 let dest = self.var();

--- a/sylt-compiler/src/lua.rs
+++ b/sylt-compiler/src/lua.rs
@@ -158,8 +158,9 @@ impl<'a, 'b, 'c> Generator<'a, 'b, 'c> {
                 IR::Index(t, a, i) => ii!(self, t, "__INDEX({}, {})", a, i),
 
                 IR::Function(upvalues, f, params) => {
-                    write!(self.out, "local ");
                     let f = self.expand(f);
+                    write!(self.out, "local {} = nil\n", f);
+                    self.indent(depth);
                     write!(self.out, "{}", f);
                     write!(self.out, "=");
                     write!(self.out, "{");

--- a/sylt-compiler/src/lua.rs
+++ b/sylt-compiler/src/lua.rs
@@ -208,8 +208,10 @@ impl<'a, 'b, 'c> Generator<'a, 'b, 'c> {
                 IR::ExternalFunction(t, e, arity) => {
                     let t = self.expand(t);
                     write!(self.out, "{}", t);
-                    write!(self.out, " = ");
-                    write!(self.out, "{ nil, ");
+                    write!(self.out, "=");
+                    write!(self.out, "{");
+                    write!(self.out, "nil");
+                    write!(self.out, ", ");
                     //
                     write!(self.out, "function(_");
                     for n in 0..*arity {

--- a/sylt-compiler/src/lua.rs
+++ b/sylt-compiler/src/lua.rs
@@ -172,7 +172,7 @@ impl<'a, 'b, 'c> Generator<'a, 'b, 'c> {
                         match u {
                             VarOrUpvalue::Var(v) => {
                                 let v = self.expand(v);
-                                write!(self.out, "{}", v);
+                                write!(self.out, "(function(x) if x == nil then return {} else {} = x end end)", v, v);
                             }
                             VarOrUpvalue::Upvalue(i, _) => {
                                 write!(self.out, "__upvalues[{}]", i + 1);
@@ -314,7 +314,7 @@ impl<'a, 'b, 'c> Generator<'a, 'b, 'c> {
                     if self.usage_count.get(t).unwrap_or(&0) > &0 {
                         let t = self.expand(t);
                         // Lua is 1-indexed
-                        write!(self.out, "local {} = __upvalues[{}]", t, i + 1);
+                        write!(self.out, "local {} = __upvalues[{}]()", t, i + 1);
                     }
                 }
 
@@ -328,7 +328,7 @@ impl<'a, 'b, 'c> Generator<'a, 'b, 'c> {
                 }
                 IR::AssignUpvalue(_, i, a) => {
                     let a = self.expand(a);
-                    write!(self.out, "__upvalues[{}] = {}", i + 1, a);
+                    write!(self.out, "__upvalues[{}]({})", i + 1, a);
                 }
                 IR::AssignIndex(t, i, a) => {
                     if self.usage_count.get(t).unwrap_or(&0) > &0 {

--- a/sylt-compiler/src/lua.rs
+++ b/sylt-compiler/src/lua.rs
@@ -61,7 +61,11 @@ struct Generator<'a, 'b, 'c> {
 }
 
 impl<'a, 'b, 'c> Generator<'a, 'b, 'c> {
-    pub fn new(usage_count: &'a HashMap<Var, usize>, var_to_name: &'c HashMap<Var, String>, out: &'b mut dyn Write) -> Self {
+    pub fn new(
+        usage_count: &'a HashMap<Var, usize>,
+        var_to_name: &'c HashMap<Var, String>,
+        out: &'b mut dyn Write,
+    ) -> Self {
         Self { usage_count, out, lut: HashMap::new(), var_to_name }
     }
 

--- a/sylt-compiler/src/lua.rs
+++ b/sylt-compiler/src/lua.rs
@@ -173,7 +173,11 @@ impl<'a, 'b, 'c> Generator<'a, 'b, 'c> {
                         match u {
                             VarOrUpvalue::Var(v) => {
                                 let v = self.expand(v);
-                                write!(self.out, "(function(x) if x == nil then return {} else {} = x end end)", v, v);
+                                write!(
+                                    self.out,
+                                    "(function(x) if x == nil then return {} else {} = x end end)",
+                                    v, v
+                                );
                             }
                             VarOrUpvalue::Upvalue(i, _) => {
                                 write!(self.out, "__upvalues[{}]", i + 1);
@@ -202,7 +206,6 @@ impl<'a, 'b, 'c> Generator<'a, 'b, 'c> {
                     write!(self.out, ")");
                     write!(self.out, "\n");
                     depth += 1;
-
                 }
 
                 IR::ExternalFunction(t, e, arity) => {

--- a/sylt-compiler/src/lua.rs
+++ b/sylt-compiler/src/lua.rs
@@ -219,6 +219,7 @@ impl<'a, 'b, 'c> Generator<'a, 'b, 'c> {
                         write!(self.out, "a_{}", n);
                     }
                     write!(self.out, ") ");
+                    write!(self.out, "return ");
                     write!(self.out, e);
                     write!(self.out, "(");
                     for n in 0..*arity {

--- a/sylt-compiler/src/lua.rs
+++ b/sylt-compiler/src/lua.rs
@@ -326,6 +326,10 @@ impl<'a, 'b, 'c> Generator<'a, 'b, 'c> {
                         write!(self.out, "{} = {}", t, a);
                     }
                 }
+                IR::AssignUpvalue(_, i, a) => {
+                    let a = self.expand(a);
+                    write!(self.out, "__upvalues[{}] = {}", i + 1, a);
+                }
                 IR::AssignIndex(t, i, a) => {
                     if self.usage_count.get(t).unwrap_or(&0) > &0 {
                         let a = self.expand(a);

--- a/sylt-compiler/src/name_resolution.rs
+++ b/sylt-compiler/src/name_resolution.rs
@@ -667,7 +667,7 @@ impl Resolver {
                 let span = *span;
                 let name = name.clone();
                 if self.is_upvalue(var) {
-                    dbg!(E::ReadUpvalue { var, name, span })
+                    E::ReadUpvalue { var, name, span }
                 } else {
                     E::Read { var, name, span }
                 }

--- a/sylt-compiler/src/name_resolution.rs
+++ b/sylt-compiler/src/name_resolution.rs
@@ -129,6 +129,7 @@ pub struct CaseBranch {
 pub enum Expression {
     Read {
         var: Ref,
+        name: String,
         span: Span,
     },
     Variant {
@@ -176,6 +177,7 @@ pub enum Expression {
         span: Span,
     },
     Function {
+        // TODO[et]: We want to know what upvalues we have.
         name: String,
         params: Vec<(String, Ref, Span, Type)>,
         ret: Type,
@@ -631,7 +633,7 @@ impl Resolver {
             AK::Read(Identifier { name, span }) => {
                 let var = self.lookup(name, *span)?;
                 let span = *span;
-                E::Read { var, span }
+                E::Read { var, name: name.clone(), span }
             }
             AK::Variant { enum_ass, variant, value } => {
                 // Checking that this is a valid type, should be done in the typechecker
@@ -686,7 +688,7 @@ impl Resolver {
                         }
                     };
                     let span = ident.span;
-                    E::Read { var, span }
+                    E::Read { var, name: "access".to_string(), span }
                 }
                 None => {
                     let value = Box::new(self.assignable(assignable)?);

--- a/sylt-compiler/src/name_resolution.rs
+++ b/sylt-compiler/src/name_resolution.rs
@@ -945,7 +945,19 @@ impl Resolver {
                     params.push((n.name.clone(), var, n.span, self.ty(t)?));
                 }
                 let ret = self.ty(ret)?;
-                let body = self.block(body)?;
+                let mut body = self.block(body)?;
+
+                if !ret.is_void() {
+                    if let Some(last) = body.last_mut() {
+                        match last {
+                            Statement::StatementExpression { value, span } => {
+                                *last = Statement::Ret { value: Some(value.clone()), span: *span };
+                            }
+                            _ => {}
+                        }
+                    };
+                }
+
                 // ------- //
                 let upvalues = self
                     .stack

--- a/sylt-compiler/src/name_resolution.rs
+++ b/sylt-compiler/src/name_resolution.rs
@@ -135,6 +135,11 @@ pub enum Expression {
         name: String,
         span: Span,
     },
+    ReadUpvalue {
+        var: Ref,
+        name: String,
+        span: Span,
+    },
     Variant {
         ty: Ref,
         variant: String,
@@ -215,6 +220,7 @@ impl Expression {
     pub fn span(&self) -> Span {
         match self {
             Expression::Read { span, .. }
+            | Expression::ReadUpvalue { span, .. }
             | Expression::Variant { span, .. }
             | Expression::Call { span, .. }
             | Expression::BlobAccess { span, .. }

--- a/sylt-compiler/src/name_resolution.rs
+++ b/sylt-compiler/src/name_resolution.rs
@@ -959,8 +959,6 @@ impl Resolver {
                     .map(|(_, var)| var)
                     .cloned()
                     .collect();
-                dbg!(&name);
-                dbg!(&upvalues);
                 self.pop_stack_frame(sf);
                 self.stack.truncate(ss);
                 E::Function {

--- a/sylt-compiler/src/name_resolution.rs
+++ b/sylt-compiler/src/name_resolution.rs
@@ -656,9 +656,13 @@ impl Resolver {
 
     fn is_upvalue(&self, var: Ref) -> bool {
         let var = &self.variables[var];
-        if var.is_global { return false; }
+        if var.is_global {
+            return false;
+        }
         let sf = self.stack_frames.last().cloned().unwrap();
-        if var.stack_frame == sf { return false; }
+        if var.stack_frame == sf {
+            return false;
+        }
         return var.captured_by.contains(&sf);
     }
 
@@ -885,7 +889,7 @@ impl Resolver {
                 let upvalues = self
                     .stack
                     .iter()
-                    .filter(|(_, var)| { self.is_upvalue(*var) })
+                    .filter(|(_, var)| self.is_upvalue(*var))
                     .map(|(_, var)| var)
                     .cloned()
                     .collect();
@@ -1159,7 +1163,7 @@ impl Resolver {
     }
 
     fn push_stack_frame(&mut self) -> StackFrameId {
-        let  stack_frame = StackFrameId(self.stack_frame_counter);
+        let stack_frame = StackFrameId(self.stack_frame_counter);
         self.stack_frame_counter += 1;
         self.stack_frames.push(stack_frame);
         stack_frame

--- a/sylt-compiler/src/name_resolution.rs
+++ b/sylt-compiler/src/name_resolution.rs
@@ -654,7 +654,7 @@ impl Resolver {
     fn is_upvalue(&self, var: Ref) -> bool {
         let stack_frame_id = self.stack_frames.last().cloned().unwrap_or(StackFrameId(0));
         let var = &self.variables[var];
-        return !var.is_global && var.captured_by.contains(&stack_frame_id);
+        return !(var.is_global || var.captured_by.contains(&stack_frame_id));
     }
 
     fn assignable(&mut self, assignable: &ParserAssignable) -> ResolveResult<Expression> {

--- a/sylt-compiler/src/preamble.lua
+++ b/sylt-compiler/src/preamble.lua
@@ -326,22 +326,16 @@ end
 function atan2(x, y) return math.atan2(y, x) end
 function list_random_choice(l) return list_get(l, math.random(0, #l - 1)) end
 
-function varargs(f)
-    return function(xs)
-        return f(unpack(xs))
-    end
-end
-
 function list_for_each(l, f)
     for _, v in pairs(l) do
-        f(v)
+        f[2](f[1], v)
     end
 end
 
 function list_map(l, f)
     local o = {}
     for k, v in pairs(l) do
-        o[k] = f(v)
+        o[k] = f[2](f[1], v)
     end
     return __LIST(o)
 end
@@ -363,7 +357,7 @@ end
 
 function list_fold(l, a, f)
     for _, v in pairs(l) do
-        a = f(v, a)
+        a = f[2](f[1], v, a)
     end
     return a
 end
@@ -371,7 +365,7 @@ end
 function list_filter(l, f)
     local o = {}
     for _, v in pairs(l) do
-        if f(v) then
+        if f[2](f[1], v) then
             table.insert(o, v)
         end
     end
@@ -386,7 +380,7 @@ end
 
 function list_find(l, p)
     for _, x in pairs(l) do
-        if p(x) then
+        if p[2](p[1], x) then
             return __VARIANT({"Just", x})
         end
     end
@@ -543,14 +537,14 @@ end
 
 function dict_for_each(dict, f)
     for _k, v in pairs(dict) do
-        f(v)
+        f[2](f[1], v)
     end
 end
 
 function dict_map(dict, f)
     local out = dict_new()
     for _k, v in pairs(dict) do
-        x = f(v)
+        x = f[2](f[1], v)
         dict_update(out, x[1], x[2])
     end
     return out
@@ -612,14 +606,14 @@ end
 
 function set_for_each(set, f)
     for _k, v in pairs(set) do
-        f(v)
+        f[2](f[1], v)
     end
 end
 
 function set_map(set, f)
     local out = dict_new()
     for _k, v in pairs(set) do
-        x = f(v)
+        x = f[2](f[1], v)
         set_add(out, x)
     end
     return out

--- a/sylt-compiler/src/ty.rs
+++ b/sylt-compiler/src/ty.rs
@@ -26,7 +26,7 @@ pub enum Type {
     Str,
     Tuple(Vec<TyID>),
     List(TyID),
-    Function(Vec<TyID>, TyID, Purity),
+    Function(Vec<TyID>, TyID, Purity, Vec<(Vec<TyID>, TyID)>),
     Blob(String, Span, BTreeMap<String, (Span, TyID)>, Vec<TyID>),
     ExternBlob(
         String,

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -944,7 +944,7 @@ impl TypeChecker {
                 )
             }
 
-            E::Function { name: _, params, ret, body, pure, span } => {
+            E::Function { name: _, params, ret, body, pure, span, upvalues: _ } => {
                 let (f_ty, ret_ty) = self.type_from_function(ctx, params, ret, *pure)?;
 
                 let ctx = if *pure { ctx.enter_pure() } else { ctx };

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1142,7 +1142,7 @@ impl TypeChecker {
         &self.types[root]
     }
 
-    fn find(&mut self, TyID(a): TyID) -> TyID {
+    pub fn find(&mut self, TyID(a): TyID) -> TyID {
         let mut root = a;
         while let Some(TyID(next)) = self.types[root].parent {
             root = next;

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1752,13 +1752,14 @@ impl TypeChecker {
     fn can_assign(&mut self, span: Span, assignable: &Expression) -> TypeResult<()> {
         use Expression as E;
         match &assignable {
-            E::Read { var, span } => {
+            E::Read { var, name, span } => {
                 if self.variables[*var].kind.immutable() {
                     return err_type_error!(
                         self,
                         *span,
                         TypeError::Assignability,
-                        "Cannot assign to constants"
+                        "Cannot assign to constants {:?}",
+                        name
                     );
                 }
             }

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -213,6 +213,10 @@ impl TypeChecker {
         res
     }
 
+    pub fn get_variable_type(&self, var: usize) -> &Type {
+        &self.types[self.variables[var].id].ty
+    }
+
     fn push_type(&mut self, ty: Type) -> TyID {
         let ty_id = TyID(self.types.len());
         self.types.push(TypeNode {

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1133,15 +1133,6 @@ impl TypeChecker {
         }
     }
 
-    fn find_no_mut(&self, TyID(a): TyID) -> &TypeNode {
-        let mut root = a;
-        while let Some(TyID(next)) = self.types[root].parent {
-            root = next;
-        }
-
-        &self.types[root]
-    }
-
     pub fn find(&mut self, TyID(a): TyID) -> TyID {
         let mut root = a;
         while let Some(TyID(next)) = self.types[root].parent {

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -1158,6 +1158,10 @@ impl TypeChecker {
         &mut self.types[ta]
     }
 
+    pub fn find_var(&mut self, var: usize) -> TyID {
+        self.find(self.variables[var].ty)
+    }
+
     pub fn find_var_type(&mut self, var: usize) -> Type {
         self.find_type(self.variables[var].ty)
     }

--- a/sylt-compiler/src/typechecker.rs
+++ b/sylt-compiler/src/typechecker.rs
@@ -694,7 +694,7 @@ impl TypeChecker {
     fn expression(&mut self, expression: &Expression, ctx: TypeCtx) -> TypeResult<RetNValue> {
         use Expression as E;
         let (expr_ret, expr) = match expression {
-            E::Read { var, span, .. } => {
+            E::Read { var, span, .. } | E::ReadUpvalue { var, span, .. } => {
                 let var = &self.variables[*var];
                 let immutable = var.kind.immutable();
                 if ctx.inside_pure && !immutable {
@@ -944,7 +944,15 @@ impl TypeChecker {
                 )
             }
 
-            E::Function { name: _, params, ret, body, pure, span, upvalues: _ } => {
+            E::Function {
+                name: _,
+                params,
+                ret,
+                body,
+                pure,
+                span,
+                upvalues: _,
+            } => {
                 let (f_ty, ret_ty) = self.type_from_function(ctx, params, ret, *pure)?;
 
                 let ctx = if *pure { ctx.enter_pure() } else { ctx };
@@ -1752,7 +1760,7 @@ impl TypeChecker {
     fn can_assign(&mut self, span: Span, assignable: &Expression) -> TypeResult<()> {
         use Expression as E;
         match &assignable {
-            E::Read { var, name, span } => {
+            E::Read { var, name, span } | E::ReadUpvalue { var, name, span } => {
                 if self.variables[*var].kind.immutable() {
                     return err_type_error!(
                         self,


### PR DESCRIPTION
# A C-backend for Sylt-lang

This is going to be one GIANT pr for all of the fixes and things I find while doing this.
The current gameplan looks something like this:
 - Make the Lua backend more powerfull and better
 - Simply copy the Lua backend and make it compile to C 
 - Inject a finished C-garbage collector (it's not that fun to write one)
 - Profit

Top of mind that needs doing right now
 1. Make the Lua backend better. All improvelents here will cascade to the C one. Some limitations right now are:
    - [x] Generate variable names in the Lua code
    - [x] Introduce idea of `upvalues`
    - [x] Introduce typeinformation in code-generation
    - [x] Introduce names carried over to runtime for debuggability
    - [x] Make all the tests run with the new upvalue-code
    - [ ] Send information about the different functions to code-gen
    - [ ] Const is const, respect the const variables to generate lightning fast code
    - [ ] Introduce generation of multiple functions
    - [ ] IR isn't complex enough, needs to understand functions and values to carry more information
    - [ ] The generated code needs to be more optimized, right now that means "looks like C".
    - [ ] Fix the typechecker so it handles functions correctly
    - [ ] Eventually make the typechecker really fast, this is mostly about reusing things (making all Int types the same might be a good starting point for example)
 2. Think about the C-representation of Sylt values. Can we lean heavily on C-function and the like?
    - Functions: needs to take a CTX for the upvalues `({ n: Int, upvalues: Value* }, fn (CTX, Value*) -> Value)`, `blobs == tuples`, Maybe hack in `bool, int, float` into `Value` directly. Upvalues need to be stack allocated. Functions need to all be global.
 3. String interning for compiler-speed (StringBackend/Default should do nicely), https://docs.rs/string-interner/latest/string_interner/
    - Will make some implementations easier since we don't have to clone strings all the time (I suspect this is taking quite some time) - and we don't care about what's inside the strings until we generate the code or throw an error.
 4. TGC looks promising, https://github.com/orangeduck/tgc
 5. Benchmark the current compiler - it's really slow, something so I know I'm getting faster - It's pretty slow right now, I don't like slow things. But it's also easier to make a correct thing faster than a fast thing correct... So...
 6. The typechecker is quite messy when it comes to functions, and it's very error prone there. I've known about these bugs for some time now, but it might be time to fix it for real.
    
   


